### PR TITLE
feat: 호스트 배포를 위한 설정 및 API 경로 변경

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ DB_ROOT_PASSWORD=admin
 
 # frontend
 FRONTEND_PORT=80
-VITE_API_URL = http://localhost:8000
 
 # DB
-DB_PORT=3306 # Default
+DB_PORT=3306

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,13 @@ async def lifespan(app: FastAPI):
     # Clean up the ML models and release the resources
 
 
-app = FastAPI(lifespan=lifespan)
+# Swagger UI와 OpenAPI 경로를 Nginx 설정에 맞게 수정
+app = FastAPI(
+    lifespan=lifespan,
+    docs_url="/docs",          # Swagger UI 경로
+    openapi_url="/openapi.json" # OpenAPI 스펙 경로
+)
+
 app.include_router(api_router)
 app.add_middleware(
     CORSMiddleware,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "${FRONTEND_PORT}:80"
     environment:
-      - VITE_API_URL=/api
+      - VITE_API_URL=http://backend:${BACKEND_PORT}
     depends_on:
       - backend
 
@@ -21,7 +21,7 @@ services:
     environment:
       DB_URL: mysql+aiomysql://${DB_ROOT}:${DB_ROOT_PASSWORD}@db:${DB_PORT}/${DB_DATABASE}
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT}:8000"
     command: >
       /bin/sh -c "
         alembic upgrade head;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,15 +5,8 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # SPA routing을 위해 404 fallback 처리
     location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    location /api/ {
-        proxy_pass http://backend:8000;  # docker-compose의 backend 서비스
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
**backend**
- FastAPI docs 및 OpenAPI 경로 명시

**frontend**
- nginx에서 /api 프록시 제거로 정적 호스팅 전환

**docker compose** 
- VITE_API_URL을 backend 서비스 주소로 수정
- backend 포트를 환경변수로 분리하여 유연성 향상