### PR TITLE
fix: 데이터베이스 리셋 API 엔드포인트 이름 변경

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,6 +65,6 @@ def hc():
     return "server is running"
 
 
-@app.get("/reset-db/zozo")
+@app.get("/zozo-manual-reset-db")
 async def reset_db():
     await db.reset_database()


### PR DESCRIPTION
- /reset-db/zozo -> /zozo-manual-reset-db 로 변경
(reset-db/zozo) => reset-db로 렌더링 됨. 
nginx setting 변경대신 endpoint 변경을 꾀함.