### PR TITLE
feat: 관리자용 참여자 및 빙고 보드 데이터 다운로드 API 추가

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -5,6 +5,7 @@ from api.bingo.bingo_boards.routes import bingo_boards_router
 from api.bingo.bingo_interaction.routes import bingo_interaction_router
 from api.integrations.routes import router as integrations_router
 from api.review.routes import review_router
+from api.admin.routes import admin_router
 
 api_router = APIRouter(prefix="/api")
 
@@ -14,6 +15,7 @@ routers = [
     bingo_interaction_router,
     integrations_router,
     review_router,
+    admin_router,
 ]
 
 for router in routers:

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -1,8 +1,13 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from core.db import AsyncSessionDepends
-from .services import set_test_bingo_board
+from .services import set_test_bingo_board, get_all_users, get_all_bingo_boards
+from core.dependencies import authenticate_user
 
-admin_router = APIRouter(prefix="/admin", tags=["admin"])
+import io
+import pandas as pd
+from starlette.responses import StreamingResponse
+
+admin_router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(authenticate_user)])
 
 @admin_router.post(
     "/zozo-manual-setting-bingo/{user_id}/{bingo_count}",
@@ -28,3 +33,146 @@ async def set_bingo_test_route(
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"서버 오류가 발생했습니다: {e}")
+
+
+@admin_router.get("/download-attendance-data", summary="참여자 데이터 다운로드")
+async def download_attendance_data(
+    db: AsyncSessionDepends,
+):
+    """
+    참여자 데이터를 CSV 파일로 다운로드합니다.
+    """
+    users = await get_all_users(db)
+    
+    user_data = [
+        {
+            "ID": user.user_id,
+            "Name": user.user_name,
+            "Email": user.user_email,
+            "Rating": user.rating,
+            "Review": user.review,
+            "AgreedAt": user.agreement_at.strftime('%Y-%m-%d %H:%M:%S') if user.agreement_at else None,
+            "CreatedAt": user.created_at.strftime('%Y-%m-%d %H:%M:%S') if user.created_at else None,
+        }
+        for user in users
+    ]
+    
+    df = pd.DataFrame(user_data)
+    
+    stream = io.StringIO()
+    df.to_csv(stream, index=False, encoding='utf-8-sig')
+    
+    response = StreamingResponse(
+        iter([stream.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=attendance.csv"}
+    )
+    
+    return response
+
+
+@admin_router.get("/download-bingo-participation-data", summary="빙고 참여 데이터 다운로드")
+async def download_bingo_participation_data(
+    db: AsyncSessionDepends,
+):
+    """
+    참여자들의 주요 빙고 참여 데이터를 CSV 파일로 다운로드합니다.
+    """
+    users = await get_all_users(db)
+    boards = await get_all_bingo_boards(db)
+
+    user_map = {user.user_id: user for user in users}
+    board_map = {board.user_id: board for board in boards}
+
+    participation_data = []
+    for user_id, user in user_map.items():
+        board = board_map.get(user_id)
+        if board:
+            selected_words = [cell['value'] for cell in board.board_data.values() if cell.get('selected')]
+            participation_data.append({
+                "ID": user.user_id,
+                "Name": user.user_name,
+                "Email": user.user_email,
+                "BingoCount": board.bingo_count,
+                "InteractionCount": board.user_interaction_count,
+                "SelectedWords": ", ".join(selected_words) if selected_words else "",
+            })
+
+    df = pd.DataFrame(participation_data)
+
+    stream = io.StringIO()
+    df.to_csv(stream, index=False, encoding='utf-8-sig')
+
+    response = StreamingResponse(
+        iter([stream.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=bingo_participation.csv"}
+    )
+
+    return response
+
+
+@admin_router.get("/download-all-interactions", summary="모든 인터랙션 데이터 다운로드")
+async def download_all_interactions(
+    db: AsyncSessionDepends,
+):
+    """
+    사용자 간의 모든 인터랙션 기록을 CSV 파일로 다운로드합니다.
+    """
+    users = await get_all_users(db)
+    boards = await get_all_bingo_boards(db)
+
+    user_map = {user.user_id: user for user in users}
+    
+    # (ReceiverID, SenderID)를 키로 사용하여 인터랙션을 그룹화합니다.
+    grouped_interactions = {}
+    
+    for board in boards:
+        receiver_user = user_map.get(board.user_id)
+        if not receiver_user:
+            continue
+
+        for cell_data in board.board_data.values():
+            sender_id = cell_data.get("interaction_id")
+            keyword = cell_data.get("value")
+
+            if sender_id and keyword:
+                sender_user = user_map.get(sender_id)
+                if not sender_user:
+                    continue
+
+                group_key = (receiver_user.user_id, sender_user.user_id)
+                
+                if group_key not in grouped_interactions:
+                    grouped_interactions[group_key] = {
+                        "ReceiverID": receiver_user.user_id,
+                        "SenderID": sender_user.user_id,
+                        "ReceiverName": receiver_user.user_name,
+                        "SenderName": sender_user.user_name,
+                        "Keywords": [],
+                        "Timestamp": board.updated_at.strftime('%Y-%m-%d %H:%M:%S') if board.updated_at else None,
+                    }
+                
+                grouped_interactions[group_key]["Keywords"].append(keyword)
+
+    # 그룹화된 데이터를 리스트로 변환하고 키워드를 콤마로 연결합니다.
+    interaction_list = list(grouped_interactions.values())
+    for item in interaction_list:
+        item["Keyword"] = ", ".join(item.pop("Keywords"))
+
+    # 시간순, 이름순으로 정렬합니다.
+    if interaction_list:
+        interaction_list.sort(key=lambda x: (x.get("Timestamp", ""), x.get("ReceiverName", ""), x.get("SenderName", "")), reverse=True)
+
+    df = pd.DataFrame(interaction_list)
+    
+    stream = io.StringIO()
+    df.to_csv(stream, index=False, encoding='utf-8-sig')
+    
+    response = StreamingResponse(
+        iter([stream.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=all_interactions.csv"}
+    )
+    
+    return response

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from core.db import AsyncSessionDepends
-from api.admin.services import set_test_bingo_board
+from .services import set_test_bingo_board
 
 admin_router = APIRouter(prefix="/admin", tags=["admin"])
 

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, HTTPException
+from core.db import AsyncSessionDepends
+from api.admin.services import set_test_bingo_board
+
+admin_router = APIRouter(prefix="/admin", tags=["admin"])
+
+@admin_router.post(
+    "/zozo-manual-setting-bingo/{user_id}/{bingo_count}",
+    summary="(관리자) 빙고 테스트 데이터 세팅",
+    description="사용자 ID와 원하는 빙고 줄 수를 입력하여 빙고판 상태를 강제로 설정합니다. bingo_count를 0으로 설정 시 빙고판을 초기화합니다.",
+)
+async def set_bingo_test_route(
+    db: AsyncSessionDepends,
+    user_id: int,
+    bingo_count: int
+):
+    """
+    관리자용 빙고 테스트 API 엔드포인트입니다.
+    """
+    try:
+        updated_board = await set_test_bingo_board(db=db, user_id=user_id, bingo_count=bingo_count)
+        return {
+            "success": True,
+            "message": f"사용자 {user_id}의 빙고가 {bingo_count}줄로 설정되었습니다.",
+            "board_data": updated_board.board_data
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"서버 오류가 발생했습니다: {e}")

--- a/backend/app/api/admin/services.py
+++ b/backend/app/api/admin/services.py
@@ -1,7 +1,9 @@
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy import select
 from core.db import AsyncSession
+from models.user import BingoUser
 from models.bingo.bingo_boards import BingoBoards
+from typing import List
 
 
 async def set_test_bingo_board(db: AsyncSession, user_id: int, bingo_count: int) -> BingoBoards:
@@ -40,3 +42,21 @@ async def set_test_bingo_board(db: AsyncSession, user_id: int, bingo_count: int)
     await db.refresh(board)
 
     return board
+
+
+async def get_all_users(db: AsyncSession) -> List[BingoUser]:
+    """
+    모든 유저 정보를 조회합니다.
+    """
+    result = await db.execute(select(BingoUser))
+    users = result.scalars().all()
+    return users
+
+
+async def get_all_bingo_boards(db: AsyncSession) -> List[BingoBoards]:
+    """
+    모든 유저의 빙고 보드 정보를 조회합니다.
+    """
+    result = await db.execute(select(BingoBoards))
+    boards = result.scalars().all()
+    return boards

--- a/backend/app/api/admin/services.py
+++ b/backend/app/api/admin/services.py
@@ -1,0 +1,40 @@
+from sqlalchemy.orm.attributes import flag_modified
+from sqlalchemy import select
+from core.db import AsyncSession
+from models.bingo.bingo_boards import BingoBoards
+
+
+async def set_test_bingo_board(db: AsyncSession, user_id: int, bingo_count: int) -> BingoBoards:
+    """
+    (비동기) 사용자의 빙고 보드를 테스트용으로 설정합니다.
+    bingo_count 수만큼 가로줄을 완성시킵니다.
+    """
+    # 1. 유저의 빙고판 조회 (비동기 방식)
+    result = await db.execute(select(BingoBoards).filter(BingoBoards.user_id == user_id))
+    board = result.scalar_one_or_none()
+
+    if not board:
+        raise ValueError("해당 사용자의 빙고 보드를 찾을 수 없습니다.")
+
+    data = board.board_data
+
+    # 2. 빙고판 초기화 및 재설정
+    # 모든 status를 0으로 초기화
+    for i in range(25):
+        if str(i) in data:
+            data[str(i)]["status"] = 0
+
+    # bingo_count만큼 가로줄 완성
+    if bingo_count > 0:
+        for i in range(bingo_count):
+            for j in range(5):
+                idx = i * 5 + j
+                if str(idx) in data:
+                    data[str(idx)]["status"] = 1
+
+    # 3. DB에 저장
+    flag_modified(board, "board_data")
+    await db.commit()
+    await db.refresh(board)
+
+    return board

--- a/backend/app/api/admin/services.py
+++ b/backend/app/api/admin/services.py
@@ -32,6 +32,8 @@ async def set_test_bingo_board(db: AsyncSession, user_id: int, bingo_count: int)
                 if str(idx) in data:
                     data[str(idx)]["status"] = 1
 
+    board.bingo_count = bingo_count
+
     # 3. DB에 저장
     flag_modified(board, "board_data")
     await db.commit()

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -2,4 +2,26 @@
 공용 Depends 모음
 """
 from typing import Annotated
-from fastapi import Depends
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from core.db import db
+import os
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+
+AsyncSessionDepends = Annotated[AsyncSession, Depends(db.get_session)]
+
+
+# Swagger/Admin Auth
+SWAGGER_USERNAME = os.environ.get("SWAGGER_USERNAME", "admin")
+SWAGGER_PASSWORD = os.environ.get("SWAGGER_PASSWORD", "admin")
+
+security = HTTPBasic()
+
+def authenticate_user(credentials: Annotated[HTTPBasicCredentials, Depends(security)]):
+    if credentials.username != SWAGGER_USERNAME or credentials.password != SWAGGER_PASSWORD:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,29 +1,14 @@
-from fastapi import FastAPI, Depends, HTTPException, status, Response
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi import FastAPI, Depends, status, Response
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
-from typing import Annotated
 
 import os
 from contextlib import asynccontextmanager
 from core.db import db
 from api import api_router
 from starlette.middleware.cors import CORSMiddleware
+from core.dependencies import authenticate_user
 
-# Swagger 인증 정보
-SWAGGER_USERNAME = os.environ.get("SWAGGER_USERNAME", "admin")
-SWAGGER_PASSWORD = os.environ.get("SWAGGER_PASSWORD", "admin")
-
-# 인증 의존성
-security = HTTPBasic()
-
-def authenticate_user(credentials: Annotated[HTTPBasicCredentials, Depends(security)]):
-    if credentials.username != SWAGGER_USERNAME or credentials.password != SWAGGER_PASSWORD:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect credentials",
-            headers={"WWW-Authenticate": "Basic"},
-        )
 
 # lifespan 유지
 @asynccontextmanager
@@ -42,11 +27,11 @@ app = FastAPI(
 
 # ✅ 실제 인증된 사용자에게만 문서 제공
 @app.get("/docs", include_in_schema=False)
-def get_docs(credentials: Annotated[HTTPBasicCredentials, Depends(authenticate_user)]):
+def get_docs(_=Depends(authenticate_user)):
     return get_swagger_ui_html(openapi_url="/openapi.json", title="Bingo API Docs")
 
 @app.get("/openapi.json", include_in_schema=False)
-def get_openapi_spec(credentials: Annotated[HTTPBasicCredentials, Depends(authenticate_user)]):
+def get_openapi_spec(_=Depends(authenticate_user)):
     return get_openapi(title="Bingo API", version="1.0.0", routes=app.routes)
 
 # 라우터 및 기타 설정
@@ -57,6 +42,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
 
 
@@ -66,7 +52,7 @@ def hc():
 
 
 @app.post("/api/zozo-manual-reset-db")
-async def reset_db(response: Response):
+async def reset_db(response: Response, include_in_schema: bool = False):
     try:
         response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, proxy-revalidate"
         response.headers["Pragma"] = "no-cache"


### PR DESCRIPTION
- Swagger 인증을 core로 옮겨 admin에서도 사용할 수 있도록 정리
- Swagger혹은 Endpoint이용해 사용자, 빙고, 인터렉션 정보 다운로드 기능 생성
  - 전체참여자 목록
    - `ID, Name, Email, Rating, Review, AgreedAt, CreatedAt`
   - 참여자별 빙고 참여 현황
    - `ID, Name, Email, BingoCount, InteractionCount, SelectedWords`
  - 전체 상호작용 기록 다운로드
    - `ReceiverID, SenderID, ReceiverName, SenderName, Keyword (그룹화), Timestamp`
- Fixes 관리자 기능 추가 #64