### PR TITLE
fix(infra): preserve api prefix in traefik routing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,8 +45,6 @@ services:
       - "traefik.http.routers.bingo-backend.rule=Host(`bingo.pseudolab-devfactory.com`) && PathPrefix(`/api`)"
       - "traefik.http.routers.bingo-backend.entrypoints=websecure"
       - "traefik.http.routers.bingo-backend.tls.certresolver=le"
-      - "traefik.http.middlewares.bingo-strip-api.stripprefix.prefixes=/api"
-      - "traefik.http.routers.bingo-backend.middlewares=bingo-strip-api"
       - "traefik.http.services.bingo-backend.loadbalancer.server.port=8000"
       - "traefik.docker.network=traefik"
 

--- a/docs/handoffs/2026-03-19-traefik-api-prefix-fix.md
+++ b/docs/handoffs/2026-03-19-traefik-api-prefix-fix.md
@@ -1,0 +1,48 @@
+## Task Metadata
+- Task ID: 2026-03-19-traefik-api-prefix-fix
+
+## Scope
+- In scope:
+  - Fix deployed API routing for `/api/auth/bingo/register` and related `/api/*` backend paths
+  - Update Docker Compose Traefik labels only
+- Out of scope:
+  - Backend route refactors
+  - Frontend API contract changes
+
+## Inputs Used
+- Source docs:
+  - `AGENTS.md`
+  - `docs/reference/agent-collaboration.md`
+- Additional constraints:
+  - Keep the smallest-impact fix
+  - Deployment/runtime topology changes require handoff metadata
+
+## Changes Made
+- Files changed:
+  - `docker-compose.yaml`
+  - `docs/handoffs/2026-03-19-traefik-api-prefix-fix.md`
+- Behavior changes:
+  - Removed the Traefik `StripPrefix(/api)` middleware from the backend router
+  - Requests matching `Host(bingo.pseudolab-devfactory.com) && PathPrefix(/api)` now reach FastAPI with the `/api` prefix intact
+
+## Validation
+- Tests run:
+  - `docker compose -f docker-compose.yaml config`
+  - `PYTHONPATH=backend/app backend/venv/bin/python -m pytest backend/app/tests/test_auth_routes.py`
+- Results:
+  - Compose config rendered successfully
+  - Auth route test passed
+- Not run and reason:
+  - Live deployment verification was not run from this workspace
+
+## Risks
+- Known risks:
+  - If the deployed environment uses separate ingress or GitOps manifests outside this repository, the same prefix behavior must match there as well
+- Follow-up needed:
+  - Confirm the deployment picked up the updated compose labels and verify `/api/auth/bingo/register` in production
+
+## Next Owner
+- Owner:
+  - Infra(lead) or deploy owner
+- Expected next action:
+  - Deploy the updated compose configuration and validate the production route


### PR DESCRIPTION
﻿## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID:

## Impact Trigger (Select At Least One)
- [ ] Cross-domain change (BE/FE/Infra)
- [ ] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [ ] BE (`backend/**`)
- [ ] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [ ] docs/reference/agent-collaboration.md

## Changes
- 

## Validation
- Tests:
- Result:
- Not run and reason:

## Guide Sync Check
- [ ] Updated Korean mirrors for changed English guides

## Handoff
- [ ] Added handoff note following docs/templates/agent-handoff.md



