### PR TITLE
feat(play): 방 내 팀원 목록 및 팀 빙고 합산 조회 API

### DIFF
--- a/backend/app/api/play/routes.py
+++ b/backend/app/api/play/routes.py
@@ -12,7 +12,7 @@ from models.bingo.bingo_boards import BingoBoards
 from models.team import Team, TeamColor
 from models.room import Room
 
-from .schema import JoinEventResponse, RoomStatusResponse, TeamStatusItem, MyEventsResponse, MyEventItem
+from .schema import JoinEventResponse, RoomStatusResponse, TeamStatusItem, MyEventsResponse, MyEventItem, RoomTeamsResponse, TeamWithMembersItem, TeamMemberItem
 
 play_router = APIRouter(prefix="/play", tags=["play"])
 
@@ -249,4 +249,93 @@ async def get_my_events(
         ok=True,
         message="참여 중인 이벤트 목록을 조회했습니다.",
         events=items,
+    )
+
+
+@play_router.get(
+    "/rooms/{room_id}/teams",
+    response_model=RoomTeamsResponse,
+    summary="방 내 팀 및 팀원 목록 조회",
+)
+async def get_room_teams(
+    room_id: int,
+    current_user: CurrentUser,
+    db: AsyncSessionDepends,
+):
+    from sqlalchemy import select as sa_select
+
+    room = await Room.get_by_id(db, room_id)
+    event = await Event.get_by_id(db, room.event_id)
+
+    if event.game_mode != GameMode.TEAM:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="팀전 이벤트가 아닙니다.")
+
+    # 방 전체 참석자 목록 1방에 조회
+    attendees_result = await db.execute(
+        sa_select(EventAttendee).where(EventAttendee.room_id == room_id)
+    )
+    attendees = attendees_result.scalars().all()
+
+    user_ids = [a.user_id for a in attendees]
+
+    user_map = {}
+    board_map = {}
+
+    if user_ids:
+        # 유저 정보 일괄 조회
+        users_result = await db.execute(
+            sa_select(BingoUser).where(BingoUser.user_id.in_(user_ids))
+        )
+        user_map = {u.user_id: u for u in users_result.scalars().all()}
+
+        # 빙고보드 정보 일괄 조회
+        boards_result = await db.execute(
+            sa_select(BingoBoards).where(
+                BingoBoards.user_id.in_(user_ids),
+                BingoBoards.event_id == room.event_id,
+            )
+        )
+        board_map = {b.user_id: b for b in boards_result.scalars().all()}
+
+    # 참석자 정보를 team_id 기준으로 그루핑
+    team_members_by_team_id = {}
+    for att in attendees:
+        if att.team_id not in team_members_by_team_id:
+            team_members_by_team_id[att.team_id] = []
+        
+        user = user_map.get(att.user_id)
+        board = board_map.get(att.user_id)
+        bingo_count = board.bingo_count if board else 0
+        
+        team_members_by_team_id[att.team_id].append(
+            TeamMemberItem(
+                user_id=att.user_id,
+                user_name=user.user_name if user else None,
+                bingo_count=bingo_count,
+            )
+        )
+
+    # 방의 팀 목록 조회
+    teams = await Team.get_by_room(db, room_id)
+    team_with_members_items = []
+
+    for team in teams:
+        members = team_members_by_team_id.get(team.id, [])
+        total_bingo = sum(m.bingo_count for m in members)
+        
+        team_with_members_items.append(
+            TeamWithMembersItem(
+                team_id=team.id,
+                color=team.color.value,
+                name=team.name,
+                total_bingo_count=total_bingo,
+                members=members,
+            )
+        )
+
+    return RoomTeamsResponse(
+        ok=True,
+        message="방 내 팀 및 팀원 목록을 조회했습니다.",
+        room_id=room_id,
+        teams=team_with_members_items,
     )

--- a/backend/app/api/play/schema.py
+++ b/backend/app/api/play/schema.py
@@ -30,6 +30,25 @@ class RoomStatusResponse(BaseSchema):
     teams: list[TeamStatusItem] = []
 
 
+class TeamMemberItem(BaseModel):
+    user_id: int
+    user_name: Optional[str] = None
+    bingo_count: int = 0
+
+
+class TeamWithMembersItem(BaseModel):
+    team_id: int
+    color: str
+    name: str
+    total_bingo_count: int = 0
+    members: list[TeamMemberItem] = []
+
+
+class RoomTeamsResponse(BaseSchema):
+    room_id: int
+    teams: list[TeamWithMembersItem] = []
+
+
 class MyEventItem(BaseModel):
     event_id: int
     event_slug: str


### PR DESCRIPTION
## Summary

- 팀전 방에 입장한 팀원 목록과 팀별 빙고 합산을 조회하는 API 추가

## 변경 사항

### 신규 엔드포인트

**`GET /api/play/rooms/{room_id}/teams`**

팀별 팀원 목록과 각 팀의 총 빙고 수를 반환합니다.

**Response:**
```json
{
  "ok": true,
  "room_id": 1,
  "teams": [
    {
      "team_id": 1,
      "color": "blue",
      "name": "파랑 팀",
      "total_bingo_count": 5,
      "members": [
        { "user_id": 1, "user_name": "홍길동", "bingo_count": 3 },
        { "user_id": 2, "user_name": "김철수", "bingo_count": 2 }
      ]
    },
    {
      "team_id": 2,
      "color": "red",
      "name": "빨강 팀",
      "total_bingo_count": 4,
      "members": [...]
    }
  ]
}
```

- 개인전 이벤트 방 조회 시 400 반환
- 유저 정보 및 빙고 보드 일괄 조회 (N+1 방지)

### 신규 스키마
- `TeamMemberItem` — 팀원 정보 (user_id, user_name, bingo_count)
- `TeamWithMembersItem` — 팀 정보 + 팀원 목록 + total_bingo_count
- `RoomTeamsResponse` — 응답 루트 스키마

## 테스트

```bash
cd backend/app
conda run -n bingo python -m pytest tests/ -v
# 76 passed
```

## Related Issues
- Related #94 #95