### PR TITLE
perf: DB 쿼리 수 감소로 API 응답 속도 개선

### DIFF
--- a/backend/app/api/admin/auth.py
+++ b/backend/app/api/admin/auth.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -11,6 +12,10 @@ logger = logging.getLogger(__name__)
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
+# supabase_id → (Admin, expires_at) 60초 캐시
+_admin_cache: dict[str, tuple[Admin, float]] = {}
+_ADMIN_CACHE_TTL = 60.0
+
 
 async def _try_supabase_admin_auth(db, token: str):
     """Supabase JWT로 Admin 인증 시도. 실패하면 None 반환."""
@@ -19,10 +24,20 @@ async def _try_supabase_admin_auth(db, token: str):
         return None
 
     email = payload.get("email")
-    if not email:
+    supabase_id = payload.get("sub")
+    if not email or not supabase_id:
         return None
 
+    # 캐시 확인 (TTL 내면 DB 조회 스킵)
+    cached = _admin_cache.get(supabase_id)
+    if cached:
+        admin, expires_at = cached
+        if time.monotonic() < expires_at:
+            return admin
+
     admin = await Admin.get_by_email(db, email)
+    if admin:
+        _admin_cache[supabase_id] = (admin, time.monotonic() + _ADMIN_CACHE_TTL)
     return admin
 
 

--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -1,4 +1,6 @@
 from collections import Counter
+
+_seed_data_cleaned = False
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from email.message import EmailMessage
@@ -433,7 +435,31 @@ async def build_event_detail(
         for index, (keyword, count) in enumerate(keyword_counter.most_common(5), start=1)
     ]
 
-    summary = await build_event_summary(session, event, actor)
+    creator = await Admin.get_by_id(session, event.admin_id)
+    progress_current = bingo_distribution.get(event.success_condition, 0)
+    summary = AdminEventSummary(
+        id=event.id,
+        slug=event.slug,
+        name=event.name,
+        created_by_id=event.admin_id,
+        created_by_email=creator.email,
+        created_by_name=creator.name,
+        location=event.location,
+        event_team=event.event_team,
+        start_at=event.start_time,
+        end_at=event.end_time,
+        admin_email=event.admin_email,
+        board_size=event.bingo_size,
+        bingo_mission_count=event.success_condition,
+        keywords=[str(k) for k in (event.keywords or [])],
+        game_mode=event.game_mode.value,
+        team_size=event.team_size,
+        participant_count=participant_count,
+        progress_current=progress_current,
+        progress_total=participant_count,
+        status=resolve_event_status(event),
+        can_edit=can_edit_event(actor, event),
+    )
     return AdminEventDetail(
         **summary.model_dump(),
         public_path=f"/event/{event.slug}",
@@ -574,6 +600,10 @@ async def approve_event_manager_request(
 
 
 async def ensure_admin_console_seed_data(session: AsyncSession) -> None:
+    global _seed_data_cleaned
+    if _seed_data_cleaned:
+        return
+
     legacy_event_ids = (
         await session.execute(select(Event.id).where(Event.slug.in_(LEGACY_SEED_EVENT_SLUGS)))
     ).scalars().all()
@@ -594,6 +624,8 @@ async def ensure_admin_console_seed_data(session: AsyncSession) -> None:
     if legacy_admin_ids:
         await session.execute(delete(Admin).where(Admin.id.in_(legacy_admin_ids)))
         await session.commit()
+
+    _seed_data_cleaned = True
 
 
 

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -11,6 +11,7 @@ from core.dependencies import authenticate_user
 from models.admin import Admin, AdminRole
 from models.event import Event, GameMode
 from models.event_attendee import EventAttendee
+from models.bingo.bingo_boards import BingoBoards
 from models.event_manager_request import EventManagerRequest, EventManagerRequestStatus
 from models.room import Room
 from models.team import Team
@@ -412,7 +413,6 @@ async def list_admin_events(
                 progress_current=progress_current,
                 progress_total=participant_count,
                 status=resolve_event_status(event),
-                publish_state=event.publish_state.value,
                 can_edit=can_edit_event(actor, event),
             )
         )

--- a/backend/app/api/bingo/bingo_interaction/services.py
+++ b/backend/app/api/bingo/bingo_interaction/services.py
@@ -75,27 +75,42 @@ class CreateBingoInteraction(BaseBingoInteraction):
                 )
 
             event_id = await self._resolve_event_id(event_slug)
+            prefetched_receiver_board = None
             if event_id is None:
-                receiver_board = await BingoBoards.get_board_by_userid(self.async_session, receive_user_id)
-                event_id = receiver_board.event_id
+                prefetched_receiver_board = await BingoBoards.get_board_by_userid(self.async_session, receive_user_id)
+                event_id = prefetched_receiver_board.event_id
 
-            is_duplicate = await BingoInteraction.has_directional_interaction(
-                self.async_session,
-                send_user_id=send_user_id,
-                receive_user_id=receive_user_id,
-                event_id=event_id,
+            # 유저 두 명 + 보드 두 개를 각각 단일 IN 쿼리로 조회
+            users_result = await self.async_session.execute(
+                select(BingoUser).where(BingoUser.user_id.in_([send_user_id, receive_user_id]))
             )
-            if is_duplicate:
-                return BingoInteractionResponse(
-                    ok=False,
-                    message="이미 동일한 참가자에게 키워드를 전달한 적이 있습니다.",
+            users = {u.user_id: u for u in users_result.scalars().all()}
+            send_user = users.get(send_user_id)
+            receive_user = users.get(receive_user_id)
+
+            if prefetched_receiver_board is not None:
+                # event_id를 receiver_board에서 얻은 경우 sender 보드만 추가 조회
+                sender_board = await BingoBoards.get_board_by_userid(self.async_session, send_user_id, event_id)
+                board = prefetched_receiver_board
+            else:
+                # sender/receiver 보드를 단일 IN 쿼리로 배치 조회
+                boards_result = await self.async_session.execute(
+                    select(BingoBoards).where(
+                        BingoBoards.user_id.in_([send_user_id, receive_user_id]),
+                        BingoBoards.event_id == event_id,
+                    )
                 )
+                boards = {b.user_id: b for b in boards_result.scalars().all()}
+                board = boards.get(receive_user_id)
+                sender_board = boards.get(send_user_id)
 
-            send_user = await BingoUser.get_user_by_id(self.async_session, send_user_id)
-            receive_user = await BingoUser.get_user_by_id(self.async_session, receive_user_id)
-            board = await BingoBoards.get_board_by_userid(self.async_session, receive_user_id, event_id)
-            selected_words = await BingoBoards.get_user_selected_words(self.async_session, send_user_id, event_id)
+            selected_words = [
+                cell.get("value")
+                for cell in (sender_board.board_data.values() if sender_board else [])
+                if cell.get("selected") in (1, True) and cell.get("value")
+            ]
 
+            # DB 중복 체크 제거 — board_data에서 Python으로 판단 (동일 결과)
             if any(
                 cell_data.get("interaction_id") == send_user_id
                 for cell_data in board.board_data.values()

--- a/backend/app/api/play/routes.py
+++ b/backend/app/api/play/routes.py
@@ -161,21 +161,26 @@ async def get_room_status(
 ):
     from sqlalchemy import select as sa_select, func
 
-    room = await Room.get_by_id(db, room_id)
-    event = await Event.get_by_id(db, room.event_id)
+    # Room + Event 단일 JOIN 쿼리
+    room_event_row = await db.execute(
+        sa_select(Room, Event).join(Event, Event.id == Room.event_id).where(Room.id == room_id)
+    )
+    result = room_event_row.one_or_none()
+    if not result:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="방을 찾을 수 없습니다.")
+    room, event = result
 
     if event.game_mode != GameMode.TEAM:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="팀전 이벤트가 아닙니다.")
 
-    participant_count = await Room.get_participant_count(db, room_id)
-
-    # 팀 목록 + 팀별 인원수를 단일 쿼리로 조회 (N+1 제거)
+    # 팀 목록 + 팀별 인원수 단일 쿼리 — participant_count도 합산으로 계산
     team_count_rows = await db.execute(
         sa_select(Team, func.count(EventAttendee.id).label("member_count"))
         .outerjoin(EventAttendee, (EventAttendee.team_id == Team.id) & (EventAttendee.room_id == room_id))
         .where(Team.room_id == room_id)
         .group_by(Team.id)
     )
+    rows = team_count_rows.all()
     team_items = [
         TeamStatusItem(
             team_id=team.id,
@@ -183,8 +188,9 @@ async def get_room_status(
             name=team.name,
             member_count=count,
         )
-        for team, count in team_count_rows.all()
+        for team, count in rows
     ]
+    participant_count = sum(count for _, count in rows)
 
     return RoomStatusResponse(
         ok=True,
@@ -258,8 +264,13 @@ async def get_room_teams(
 ):
     from sqlalchemy import select as sa_select
 
-    room = await Room.get_by_id(db, room_id)
-    event = await Event.get_by_id(db, room.event_id)
+    room_event_row = await db.execute(
+        sa_select(Room, Event).join(Event, Event.id == Room.event_id).where(Room.id == room_id)
+    )
+    result = room_event_row.one_or_none()
+    if not result:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="방을 찾을 수 없습니다.")
+    room, event = result
 
     if event.game_mode != GameMode.TEAM:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="팀전 이벤트가 아닙니다.")


### PR DESCRIPTION
## 배경

DB 서버가 시드니(ap-southeast-2)에 있어 쿼리 1회당 RTT ~163ms 발생.
N+1 제거(#123) 이후에도 남아있던 불필요한 쿼리들을 추가 제거.

## 버그 수정

### `GET /admin/events` 500 오류 수정 (`routes.py`)
- 머지 충돌 해소 과정에서 스키마에서 삭제된 `publish_state` 필드 참조가 잔존
- `BingoBoards` import 누락으로 이벤트 목록 조회 시 `NameError` 발생
- 두 문제 모두 제거하여 정상 동작 복구

## 성능 개선

### Admin 세션 캐시 (`auth.py`)
- `authenticate_admin_session`이 매 요청마다 `Admin.get_by_email` DB 조회 실행
- supabase `sub`를 키로 60초 메모리 캐시 적용
- **절감: 첫 요청 이후 모든 어드민 API ~163ms**

### `ensure_admin_console_seed_data` 중복 실행 방지 (`console_services.py`)
- 레거시 데이터 정리용 함수가 어드민 API 11개 전체에서 매 요청마다 실행
- 모듈 레벨 플래그로 앱 기동 후 1회만 실행되도록 변경
- **절감: 모든 어드민 API 요청마다 쿼리 2~4개 제거**

### `build_event_detail` 중복 조회 제거 (`console_services.py`)
- JOIN으로 이미 가져온 참가자/빙고 데이터를 `build_event_summary`에서 재조회
- 이미 가진 데이터로 직접 `AdminEventSummary` 구성
- **절감: 이벤트 상세 조회 ~490ms**

### `CreateBingoInteraction` 쿼리 최적화 (`bingo_interaction/services.py`)
- 유저 2명 개별 조회 → `IN` 쿼리 1개로 통합
- DB 중복 체크(`has_directional_interaction`) 제거 → board_data Python 검사로 대체
- event_slug 있을 때 sender/receiver 보드 단일 `IN` 쿼리 배치 조회
- **절감: 키워드 교환 요청 쿼리 ~3개 감소**

### `get_room_status`, `get_room_teams` JOIN 통합 (`play/routes.py`)
- Room + Event 분리 조회 → 단일 JOIN 쿼리
- `participant_count` 별도 쿼리 제거, team count 합산으로 계산
- **절감: 팀전 방 조회 ~330ms**

## 테스트

- `tests/test_admin_console_services.py` 14/14 통과
- 로컬 서버 기동 후 어드민/참가자 플로우 수동 확인