### PR TITLE
test: add local DB integration coverage

### DIFF
--- a/backend/TESTING.md
+++ b/backend/TESTING.md
@@ -1,0 +1,25 @@
+# Backend Testing
+
+## Local DB-backed integration tests
+
+Automated integration tests must not use Supabase. Start the isolated local test database with:
+
+```sh
+docker compose -f docker-compose.test.yaml up -d postgres-test
+```
+
+Then run the DB-backed tests with:
+
+```sh
+cd backend
+ENV=test TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test \
+  PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py
+```
+
+The reset guard requires all of these conditions before dropping or recreating tables:
+
+- `ENV=test`
+- the database host is local (`localhost`, `127.0.0.1`, `::1`, or `postgres-test`)
+- the database name contains `test`
+
+The default development and production compose files do not start this database. Production deploys through k8s/ArgoCD and must keep using the production database connection outside this test flow.

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -2,6 +2,7 @@ import os
 from asyncio import current_task
 from core.log import logger
 from typing import Annotated, AsyncIterator
+from urllib.parse import urlparse
 from uuid import uuid4
 from fastapi import Depends
 from sqlalchemy.exc import SQLAlchemyError
@@ -17,6 +18,24 @@ from dotenv import load_dotenv
 from models.base import Base
 
 load_dotenv("config/.env", override=True)
+
+
+LOCAL_TEST_DB_HOSTS = {"localhost", "127.0.0.1", "::1", "postgres-test"}
+
+
+def assert_safe_test_database_url(db_url: str | None = None) -> None:
+    resolved_db_url = db_url or os.getenv("DB_URL", "")
+    parsed = urlparse(resolved_db_url)
+    database_name = parsed.path.lstrip("/")
+
+    if os.getenv("ENV") != "test":
+        raise RuntimeError("Database reset is only allowed when ENV=test.")
+
+    if parsed.hostname not in LOCAL_TEST_DB_HOSTS:
+        raise RuntimeError("Database reset is only allowed for a local test database host.")
+
+    if "test" not in database_name.lower():
+        raise RuntimeError("Database reset is only allowed when the database name contains 'test'.")
 
 
 class Database:
@@ -45,12 +64,15 @@ class Database:
         self.async_scoped_session = async_scoped_session(self.async_session_factory, scopefunc=current_task)
 
     async def create_database(self) -> None:
-        if os.getenv("ENV") == "test":
-            async with self.async_engine.begin() as conn:
-                # await conn.run_sync(Base.metadata.drop_all)
-                await conn.run_sync(Base.metadata.create_all)
+        if os.getenv("ENV") != "test":
+            return
+
+        assert_safe_test_database_url()
+        async with self.async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
     async def reset_database(self) -> None:
+        assert_safe_test_database_url()
         async with self.async_engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
             await conn.run_sync(Base.metadata.create_all)

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,0 +1,77 @@
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+import models  # noqa: F401 - imports all model metadata for Base.metadata.create_all.
+from core.db import assert_safe_test_database_url
+from models.base import Base
+
+
+LOCAL_TEST_DB_URL = "postgresql+asyncpg://event_bingo_test:event_bingo_test@localhost:55432/event_bingo_test"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-db-integration",
+        action="store_true",
+        default=False,
+        help="run DB-backed integration tests against the local test Postgres database",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "db_integration: requires the local test Postgres database")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-db-integration"):
+        return
+
+    skip_marker = pytest.mark.skip(reason="requires --run-db-integration and a guarded local test DB")
+    for item in items:
+        if "db_integration" in item.keywords:
+            item.add_marker(skip_marker)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _get_local_test_db_url() -> str:
+    database_url = os.getenv("TEST_DB_URL") or os.getenv("DB_URL") or LOCAL_TEST_DB_URL
+    if os.getenv("ENV") != "test":
+        pytest.skip("DB integration tests require ENV=test.")
+
+    assert_safe_test_database_url(database_url)
+    return database_url
+
+
+@pytest.fixture
+async def integration_db_session() -> AsyncIterator[AsyncSession]:
+    database_url = _get_local_test_db_url()
+    engine = create_async_engine(database_url, poolclass=NullPool)
+    session_factory = async_sessionmaker(
+        bind=engine,
+        autoflush=False,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+    except OperationalError as exc:
+        await engine.dispose()
+        pytest.skip(f"Local test database is not reachable: {exc}")
+
+    async with session_factory() as session:
+        yield session
+        await session.rollback()
+
+    await engine.dispose()

--- a/backend/app/tests/test_auth_routes.py
+++ b/backend/app/tests/test_auth_routes.py
@@ -65,7 +65,7 @@ def test_resolve_participant_search_name_falls_back_to_user_name():
     assert resolve_participant_search_name(board, user) == "기본 이름"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_bingo_search_participants_uses_event_attendee_search(monkeypatch: pytest.MonkeyPatch):
     event = type("EventStub", (), {"id": 7})()
     participant_rows = [

--- a/backend/app/tests/test_bingo_interaction_db_integration.py
+++ b/backend/app/tests/test_bingo_interaction_db_integration.py
@@ -1,0 +1,155 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from sqlalchemy import select
+
+from api.bingo.bingo_interaction.services import CreateBingoInteraction
+from models.admin import Admin, AdminRole
+from models.bingo import BingoBoards, BingoInteraction
+from models.event import Event
+from models.event_attendee import EventAttendee
+from models.user import BingoUser
+
+
+pytestmark = pytest.mark.db_integration
+
+
+def _board_data(*, ai_status: int = 0, selected_ai: int = 0) -> dict:
+    return {
+        "0": {"value": "AI", "status": ai_status, "selected": selected_ai},
+        "1": {"value": "ML", "status": 0, "selected": 0},
+        "2": {"value": "Design", "status": 0, "selected": 0},
+        "3": {"value": "Infra", "status": 0, "selected": 0},
+    }
+
+
+async def _seed_exchange_event(session):
+    now = datetime.now(ZoneInfo("Asia/Seoul"))
+    admin = await Admin.create(
+        session,
+        email="test-admin@example.com",
+        password="password",
+        name="테스트 관리자",
+        role=AdminRole.ADMIN,
+    )
+    event = await Event.create(
+        session,
+        name="Issue 81 Regression",
+        slug="issue-81-regression",
+        location="테스트 장소",
+        event_team="QA",
+        start_time=now - timedelta(hours=1),
+        end_time=now + timedelta(hours=1),
+        admin_id=admin.id,
+        admin_email=admin.email,
+        bingo_size=2,
+        success_condition=1,
+        keywords=["AI", "ML", "Design", "Infra"],
+    )
+    sender = await BingoUser.create(
+        session,
+        user_name="보내는 사람",
+        password="password",
+        user_email="sender@example.com",
+    )
+    receiver = await BingoUser.create(
+        session,
+        user_name="받는 사람",
+        password="password",
+        user_email="receiver@example.com",
+    )
+    await EventAttendee.create(session, event.id, sender.user_id, selected_keywords=["AI"])
+    await EventAttendee.create(session, event.id, receiver.user_id)
+
+    return event, sender, receiver
+
+
+@pytest.mark.anyio
+async def test_exchange_persists_history_and_matching_board_update(integration_db_session):
+    event, sender, receiver = await _seed_exchange_event(integration_db_session)
+    await BingoBoards.create(
+        integration_db_session,
+        sender.user_id,
+        event.id,
+        _board_data(ai_status=1, selected_ai=1),
+        display_name="보내는 사람",
+    )
+    await BingoBoards.create(
+        integration_db_session,
+        receiver.user_id,
+        event.id,
+        _board_data(),
+        display_name="받는 사람",
+    )
+
+    response = await CreateBingoInteraction(integration_db_session).execute(
+        '["AI"]',
+        sender.user_id,
+        receiver.user_id,
+        event_slug=event.slug,
+    )
+    await integration_db_session.commit()
+
+    receiver_board = await BingoBoards.get_board(integration_db_session, receiver.user_id, event.id)
+    history = (
+        await integration_db_session.execute(
+            select(BingoInteraction).where(
+                BingoInteraction.send_user_id == sender.user_id,
+                BingoInteraction.receive_user_id == receiver.user_id,
+                BingoInteraction.event_id == event.id,
+            )
+        )
+    ).scalar_one()
+
+    assert response.ok is True
+    assert response.updated_words == ["AI"]
+    assert history.word_id_list == '["AI"]'
+    assert receiver_board.board_data["0"]["status"] == 1
+    assert receiver_board.board_data["0"]["interaction_id"] == sender.user_id
+    assert receiver_board.user_interaction_count == 1
+
+
+@pytest.mark.anyio
+async def test_exchange_keeps_history_when_no_receiver_cell_changes(integration_db_session):
+    event, sender, receiver = await _seed_exchange_event(integration_db_session)
+    await BingoBoards.create(
+        integration_db_session,
+        sender.user_id,
+        event.id,
+        _board_data(ai_status=1, selected_ai=1),
+        display_name="보내는 사람",
+    )
+    await BingoBoards.create(
+        integration_db_session,
+        receiver.user_id,
+        event.id,
+        _board_data(ai_status=1),
+        display_name="받는 사람",
+    )
+
+    response = await CreateBingoInteraction(integration_db_session).execute(
+        '["AI"]',
+        sender.user_id,
+        receiver.user_id,
+        event_slug=event.slug,
+    )
+    await integration_db_session.commit()
+
+    receiver_board = await BingoBoards.get_board(integration_db_session, receiver.user_id, event.id)
+    histories = (
+        await integration_db_session.execute(
+            select(BingoInteraction).where(
+                BingoInteraction.send_user_id == sender.user_id,
+                BingoInteraction.receive_user_id == receiver.user_id,
+                BingoInteraction.event_id == event.id,
+            )
+        )
+    ).scalars().all()
+
+    assert response.ok is True
+    assert response.updated_words == []
+    assert len(histories) == 1
+    assert receiver_board.board_data["0"]["status"] == 1
+    assert "interaction_id" not in receiver_board.board_data["0"]
+    assert receiver_board.user_interaction_count == 1

--- a/backend/app/tests/test_bingo_interaction_services.py
+++ b/backend/app/tests/test_bingo_interaction_services.py
@@ -28,7 +28,7 @@ class FakeExecuteResult:
         return FakeScalarResult(self._values)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_bingo_interaction_rejects_duplicate_direction(monkeypatch):
     receiver_board = SimpleNamespace(
         user_id=2,
@@ -73,7 +73,7 @@ async def test_create_bingo_interaction_rejects_duplicate_direction(monkeypatch)
     assert "이미 동일한 참가자" in response.message
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_bingo_interaction_updates_board_and_creates_record(monkeypatch):
     receiver_board = SimpleNamespace(
         user_id=2,
@@ -192,7 +192,7 @@ async def test_create_bingo_interaction_updates_board_and_creates_record(monkeyp
     assert receiver_board.user_interaction_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_user_all_interactions_includes_user_names_and_cursor(monkeypatch):
     captured: dict[str, int | None] = {}
     interaction = SimpleNamespace(

--- a/backend/app/tests/test_bingo_login_service.py
+++ b/backend/app/tests/test_bingo_login_service.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from api.auth.services.bingo_login import RegisterBingoUser
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_register_bingo_user_allows_blank_name_for_google_bridge(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,19 @@
+services:
+  postgres-test:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: event_bingo_test
+      POSTGRES_USER: event_bingo_test
+      POSTGRES_PASSWORD: event_bingo_test
+    ports:
+      - "${TEST_POSTGRES_PORT:-55432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U event_bingo_test -d event_bingo_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - event-bingo-test-postgres:/var/lib/postgresql/data
+
+volumes:
+  event-bingo-test-postgres:

--- a/docs/handoffs/2026-05-14-test-readiness-team-sync.md
+++ b/docs/handoffs/2026-05-14-test-readiness-team-sync.md
@@ -1,0 +1,60 @@
+# Agent Handoff
+
+## Task Metadata
+- Task ID: 2026-05-14-test-readiness-team-sync
+
+## Scope
+- In scope: Team Lead Mode test-readiness assessment, isolated worktree delegation, clear backend/frontend test harness improvements, local test DB setup, and DB-backed issue #81 regression coverage.
+- Out of scope: k8s/ArgoCD production manifests, production Supabase DB changes, Supabase Auth/Realtime automation, team-mode release scope, and report feature scope.
+
+## Inputs Used
+- Source docs: `docs/reference/project-requirements.md`, `docs/reference/service-user-flow.md`, `docs/reference/design-guide.md`, `docs/reference/agent-collaboration.md`
+- Additional constraints: Work in separate git worktrees because multiple local agents are running in parallel. Automated integration tests must not use the only production Supabase DB. Docker Compose is local/dev/test tooling only; production deployment remains k8s/ArgoCD.
+
+## Changes Made
+- Files changed:
+  - `backend/app/tests/conftest.py`
+  - `backend/app/tests/test_auth_routes.py`
+  - `backend/app/tests/test_bingo_interaction_services.py`
+  - `backend/app/tests/test_bingo_login_service.py`
+  - `backend/app/core/db.py`
+  - `backend/app/tests/test_bingo_interaction_db_integration.py`
+  - `backend/TESTING.md`
+  - `docker-compose.test.yaml`
+  - `docs/reference/local-test-db.md`
+  - `docs/reference/local-test-db.ko.md`
+  - `frontend/src/modules/Bingo/bingoGameUtils.test.ts`
+- Behavior changes: No production behavior changed. Backend async tests now run through the installed AnyIO pytest plugin. DB reset paths now fail unless `ENV=test` and the database URL is a local test database. Frontend bingo utility tests now cover pending keyword filtering and interaction record merge/deduplication behavior.
+
+## Validation
+- Tests run:
+  - `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests`
+  - `npm test`
+  - `npm run lint`
+  - `npm run build`
+  - `npm run e2e`
+  - `docker compose -f docker-compose.test.yaml up -d postgres-test`
+  - `ENV=test TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py -q`
+  - `docker compose -f docker-compose.test.yaml down -v`
+- Results:
+  - Backend default suite: 105 passed, 2 DB integration tests skipped by default, 1 Pydantic deprecation warning.
+  - Backend DB integration opt-in: 2 passed, 1 Pydantic deprecation warning.
+  - Frontend unit: 13 files passed, 60 tests passed.
+  - Frontend lint: passed.
+  - Frontend build: passed with existing chunk-size warning.
+  - Frontend E2E: 9 passed.
+- Not run and reason: Real Supabase Auth/Realtime automation and full frontend+backend+DB E2E were not added in this step.
+
+## Risks
+- Known risks:
+  - Overall test readiness is improved but not fully operationally complete.
+  - Playwright coverage is mostly mocked and does not systematically cover both required design-guide viewports.
+  - Supabase-local auth/data paths are not covered by integration tests.
+- Follow-up needed:
+  - Decide whether incoming exchange polling and board refresh must be a required E2E regression.
+  - Add mobile bingo-service E2E, desktop admin E2E, and mobile+desktop homepage viewport coverage according to the agreed scope.
+  - Decide whether a separate non-production Supabase project is needed later for auth/realtime tests.
+
+## Next Owner
+- Owner: Frontend and QA next for viewport/E2E coverage; backend-api for additional DB-backed route integration if needed.
+- Expected next action: Add service-flow E2E coverage around incoming exchange board refresh/polling fallback, then define whether Realtime automation is required for the pilot.

--- a/docs/reference/local-test-db.ko.md
+++ b/docs/reference/local-test-db.ko.md
@@ -1,0 +1,58 @@
+# 로컬 테스트 데이터베이스 가이드
+
+## 목적
+자동화 integration 테스트에는 폐기 가능한 로컬 데이터베이스를 사용합니다. 운영 Supabase 데이터베이스에는 파괴적인 자동화 테스트를 실행하지 않습니다.
+
+## 환경 경계
+- 운영 배포는 `Pseudo-Lab/DevFactory-Ops`의 k8s와 ArgoCD로 관리합니다. Docker Compose는 운영 배포 기준이 아닙니다.
+- `docker-compose.dev.yaml`은 사람이 로컬 개발과 화면 확인에 사용하는 환경입니다.
+- `docker-compose.test.yaml`은 스키마 초기화와 데이터 삭제가 가능한 자동화 테스트 전용 환경입니다.
+- 운영 Supabase 데이터베이스는 `ENV=test`, `TEST_DB_URL`, DB reset fixture와 함께 사용하면 안 됩니다.
+
+## 테스트 데이터베이스
+로컬 테스트 데이터베이스를 시작합니다.
+
+```bash
+docker compose -f docker-compose.test.yaml up -d postgres-test
+```
+
+호스트 머신에서는 이 URL을 사용합니다.
+
+```bash
+export ENV=test
+export TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test
+```
+
+DB 기반 backend 테스트를 실행합니다.
+
+```bash
+cd backend
+PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py
+```
+
+폐기 가능한 데이터베이스를 정리합니다.
+
+```bash
+docker compose -f docker-compose.test.yaml down -v
+```
+
+## 안전 규칙
+- DB integration fixture는 반드시 `ENV=test`를 요구해야 합니다.
+- DB integration fixture는 `localhost`, `127.0.0.1`, `::1`, `postgres-test`의 `event_bingo_test` 데이터베이스만 reset할 수 있어야 합니다.
+- 테스트 데이터는 개발/운영 데이터와 분리합니다.
+- 파괴적인 setup이 필요한 테스트는 테스트 데이터베이스 경로에만 추가합니다.
+
+## 현재 소규모 운영 서비스 테스트 범위
+- 빙고 서비스: 모바일 viewport 필수
+- 관리자 페이지: 데스크톱 viewport 필수
+- 홈페이지: 모바일과 데스크톱 viewport 필수
+- 오프라인 행사 운영에서는 Realtime이 목표입니다. 다만 명시적으로 문서화하면 polling 또는 refresh fallback을 허용할 수 있습니다.
+
+## Issue 81 회귀 기준
+키워드 교환은 운영자가 누가 누구와 만났는지 알아야 하므로 항상 interaction history를 보존해야 합니다.
+
+receiver 보드 셀을 갱신할 수 있는 경우 같은 교환에서 다음 두 가지가 함께 저장되어야 합니다.
+- `bingo_interaction` row
+- receiver 보드의 status와 interaction marker
+
+receiver 보드에서 갱신할 수 있는 셀이 없는 경우에도 교환은 성공이며, 보드 셀 변경 없이 history를 보존해야 합니다.

--- a/docs/reference/local-test-db.md
+++ b/docs/reference/local-test-db.md
@@ -1,0 +1,58 @@
+# Local Test Database Guide
+
+## Purpose
+Use a disposable local database for automated integration tests. Do not run destructive automated tests against the production Supabase database.
+
+## Environment Boundaries
+- Production deploy is managed through k8s and ArgoCD in `Pseudo-Lab/DevFactory-Ops`; Docker Compose is not a production deployment source.
+- `docker-compose.dev.yaml` is for human local development and manual screen checks.
+- `docker-compose.test.yaml` is for automated tests that may reset schema and delete data.
+- The production Supabase database must not be used with `ENV=test`, `TEST_DB_URL`, or DB reset fixtures.
+
+## Test Database
+Start the local test database:
+
+```bash
+docker compose -f docker-compose.test.yaml up -d postgres-test
+```
+
+Use this URL from the host machine:
+
+```bash
+export ENV=test
+export TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test
+```
+
+Run DB-backed backend tests:
+
+```bash
+cd backend
+PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py
+```
+
+Clean up the disposable database:
+
+```bash
+docker compose -f docker-compose.test.yaml down -v
+```
+
+## Safety Rules
+- DB integration fixtures must require `ENV=test`.
+- DB integration fixtures must only reset a database named `event_bingo_test` on `localhost`, `127.0.0.1`, `::1`, or `postgres-test`.
+- Keep test data isolated from development and production data.
+- If a test needs destructive setup, add it only to the test database path.
+
+## Current Pilot-Service Test Scope
+- Bingo service: mobile viewport is mandatory.
+- Admin page: desktop viewport is mandatory.
+- Homepage: mobile and desktop viewports are mandatory.
+- Realtime is the target for offline event operation, but polling or refresh fallback may be accepted when explicitly documented.
+
+## Issue 81 Regression Rule
+Keyword exchange must always preserve interaction history because operators need to know who met whom.
+
+When receiver board cells can be updated, the same exchange must persist both:
+- a `bingo_interaction` row
+- the receiver board status and interaction marker
+
+When no receiver board cell can be updated, the exchange is still successful and must preserve history without mutating board cells.

--- a/frontend/src/modules/Bingo/bingoGameUtils.test.ts
+++ b/frontend/src/modules/Bingo/bingoGameUtils.test.ts
@@ -8,9 +8,11 @@ import {
   buildIncomingKeywordAlert,
   buildPreviewBoard,
   buildExchangeHistory,
+  getPendingKeywordsForBoard,
   getBingoMissionProgressPercent,
   getCompletedLines,
   getLatestIncomingBatch,
+  mergeInteractionRecords,
 } from "./bingoGameUtils";
 
 describe("getLatestIncomingBatch", () => {
@@ -136,6 +138,21 @@ describe("buildIncomingKeywordAlert", () => {
   });
 });
 
+describe("getPendingKeywordsForBoard", () => {
+  const board: BingoCell[] = [
+    { id: 0, value: "AI", selected: 1, status: 1 },
+    { id: 1, value: "ML", selected: 1, status: 0 },
+    { id: 2, value: "Design", selected: 0, status: 0 },
+    { id: 3, value: "Infra", selected: 0, status: 1 },
+  ];
+
+  it("returns only unique incoming keywords that can still update the board", () => {
+    expect(
+      getPendingKeywordsForBoard(board, ["AI", "ML", "ML", "Infra", "Unknown"])
+    ).toEqual(["ML"]);
+  });
+});
+
 describe("getCompletedLines", () => {
   it("returns completed rows, columns, and diagonals", () => {
     const board: BingoCell[] = Array.from({ length: 9 }, (_, index) => ({
@@ -149,6 +166,68 @@ describe("getCompletedLines", () => {
       { type: "diagonal", index: 1 },
       { type: "diagonal", index: 2 },
     ]);
+  });
+});
+
+describe("mergeInteractionRecords", () => {
+  it("deduplicates polling deltas by interaction id and keeps latest records first", () => {
+    const currentRecords: InteractionRecord[] = [
+      {
+        interaction_id: 10,
+        send_user_id: 1,
+        receive_user_id: 2,
+        send_user_name: "나",
+        receive_user_name: "상대 A",
+        created_at: "2026-03-19T10:00:00.000Z",
+        word_id_list: "[\"AI\"]",
+      },
+      {
+        interaction_id: 11,
+        send_user_id: 3,
+        receive_user_id: 1,
+        send_user_name: "상대 B",
+        receive_user_name: "나",
+        created_at: "2026-03-19T10:01:00.000Z",
+        word_id_list: "[\"ML\"]",
+      },
+    ];
+    const incomingRecords: InteractionRecord[] = [
+      {
+        interaction_id: 11,
+        send_user_id: 3,
+        receive_user_id: 1,
+        send_user_name: "상대 B",
+        receive_user_name: "나",
+        created_at: "2026-03-19T10:01:00.000Z",
+        word_id_list: "[\"ML\"]",
+      },
+      {
+        interaction_id: 12,
+        send_user_id: 1,
+        receive_user_id: 4,
+        send_user_name: "나",
+        receive_user_name: "상대 C",
+        created_at: "2026-03-19T10:02:00.000Z",
+        word_id_list: "[\"Infra\"]",
+      },
+    ];
+
+    const result = mergeInteractionRecords(currentRecords, incomingRecords);
+
+    expect(result.map((record) => record.interaction_id)).toEqual([12, 11, 10]);
+  });
+
+  it("deduplicates records without ids by sender, receiver, timestamp, and keywords", () => {
+    const record: InteractionRecord = {
+      send_user_id: 5,
+      receive_user_id: 1,
+      send_user_name: "상대 D",
+      receive_user_name: "나",
+      created_at: "2026-03-19T10:03:00.000Z",
+      word_id_list: ["Design"],
+    };
+
+    expect(mergeInteractionRecords([record], [{ ...record }])).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: 2026-05-14-test-readiness-team-sync
- Adds local disposable Postgres test DB support and DB-backed bingo exchange regression coverage.

## Impact Trigger (Select At Least One)
- [x] Cross-domain change (BE/FE/Infra)
- [x] API/Auth/DB schema or migration change affecting another domain
- [x] Source-of-truth guide change under docs/*.md
- [x] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [x] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [x] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [x] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [x] docs/reference/project-requirements.md
- [x] docs/reference/service-user-flow.md
- [x] docs/reference/design-guide.md (if applicable)
- [x] docs/reference/agent-collaboration.md

## Changes
- Adds `docker-compose.test.yaml` with an isolated `postgres-test` service for local/CI DB-backed tests.
- Adds backend DB reset guards so destructive reset paths require `ENV=test`, a local host, and a test database name.
- Adds opt-in pytest DB integration support with `--run-db-integration`.
- Adds issue #81 style DB-backed regression tests for exchange history plus board mutation, including the no-board-change history-preserved case.
- Converts existing async backend tests to the installed AnyIO pytest marker.
- Adds frontend bingo utility tests for pending keyword filtering and interaction merge/dedupe behavior.
- Documents local test DB boundaries and keeps Korean mirror in sync.

## Validation
- Tests:
  - `PYTHONPYCACHEPREFIX=/tmp/event-bingo-pycache python3 -m py_compile backend/app/core/db.py backend/app/tests/conftest.py backend/app/tests/test_bingo_interaction_db_integration.py`
  - `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests`
  - `npm test -- bingoGameUtils`
  - `docker compose -f docker-compose.test.yaml up -d postgres-test`
  - `ENV=test TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py -q`
  - `docker compose -f docker-compose.test.yaml down -v`
  - Full frontend test/lint/build/e2e were run on the original integrated branch before PR split.
- Result:
  - Backend default suite: 105 passed, 2 DB integration tests skipped by default, 1 Pydantic deprecation warning.
  - Backend DB integration opt-in: 2 passed, 1 Pydantic deprecation warning.
  - `bingoGameUtils`: 17 passed.
  - Full integrated validation before split: frontend unit 60 passed, lint passed, build passed, E2E 9 passed.
- Not run and reason:
  - Supabase Auth/Realtime automation was not added; local disposable DB integration is the agreed next step because production Supabase is the only current remote DB.

## Guide Sync Check
- [x] Updated Korean mirrors for changed English guides

## Handoff
- [x] Added handoff note following docs/templates/agent-handoff.md
