### PR TITLE
최소 CI 워크플로 추가

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,117 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  frontend-e2e:
+    name: Frontend E2E Smoke
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Landing page smoke test
+        run: npm run e2e -- landing-page.spec.ts
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: frontend/test-results/
+          if-no-files-found: ignore
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Unit tests
+        env:
+          PYTHONPATH: app
+        run: pytest app/tests --ignore=app/tests/test_bingo_interaction_db_integration.py


### PR DESCRIPTION
## 요약
- PR/push/main 수동 실행에서 동작하는 최소 CI 워크플로를 추가했습니다.
- 프론트엔드 lint, unit test, build를 기본 게이트로 구성했습니다.
- 랜딩 페이지 Playwright smoke E2E와 백엔드 pytest unit test를 별도 job으로 구성했습니다.

## 변경 내용
- `.github/workflows/ci.yaml` 추가
- `Frontend` job
  - `npm ci`
  - `npm run lint`
  - `npm test`
  - `npm run build`
- `Frontend E2E Smoke` job
  - Chromium 설치
  - `npm run e2e -- landing-page.spec.ts`
  - 실패 시 Playwright report/test-results artifact 업로드
- `Backend` job
  - Python 3.11 설정
  - `pip install -r requirements.txt pytest`
  - `PYTHONPATH=app pytest app/tests --ignore=app/tests/test_bingo_interaction_db_integration.py`

## 검증
- 로컬에서 `npx prettier --check ../.github/workflows/ci.yaml` 통과
- 로컬에서 `npm run lint` 통과
- 로컬에서 `npm test` 통과
- 임시 venv에서 백엔드 pytest 105개 통과

## 제외한 범위
- DB 통합 테스트는 이번 최소 CI에서 제외했습니다.
- 실제 DB가 필요한 테스트는 별도 workflow 또는 nightly/staging gate로 분리하는 것이 안전합니다.
