### PR TITLE
백엔드 DB 통합 테스트 워크플로 추가

### DIFF
--- a/.github/workflows/backend-db-integration.yaml
+++ b/.github/workflows/backend-db-integration.yaml
@@ -1,0 +1,70 @@
+name: Backend DB Integration
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/backend-db-integration.yaml"
+      - "backend/**"
+      - "docker-compose.test.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/backend-db-integration.yaml"
+      - "backend/**"
+      - "docker-compose.test.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: backend-db-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  db-integration:
+    name: Backend DB Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: event_bingo_test
+          POSTGRES_USER: event_bingo_test
+          POSTGRES_PASSWORD: event_bingo_test
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U event_bingo_test -d event_bingo_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run DB integration tests
+        env:
+          ENV: test
+          PYTHONPATH: app
+          TEST_DB_URL: postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test
+        run: pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py


### PR DESCRIPTION
## 요약
- 백엔드 DB 통합 테스트 전용 GitHub Actions 워크플로를 추가했습니다.
- PR 필수 게이트가 아니라 `main` push와 수동 실행에서 먼저 안정성을 확인하도록 구성했습니다.
- Postgres service container를 사용해 실제 DB-backed 테스트를 실행합니다.

## 변경 내용
- `.github/workflows/backend-db-integration.yaml` 추가
- `postgres:16-alpine` service container 구성
- `ENV=test`, `TEST_DB_URL`, `PYTHONPATH=app` 설정
- `pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py` 실행

## 검증
- `npx prettier --check ../.github/workflows/backend-db-integration.yaml` 통과
- 로컬 Docker Postgres에서 아래 명령 통과
  - `ENV=test PYTHONPATH=app TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test pytest --run-db-integration app/tests/test_bingo_interaction_db_integration.py`
  - 결과: 2 passed

## 참고
- 처음부터 PR 필수 체크로 강제하지 않고, main push/수동 실행으로 안정화한 뒤 필수화 여부를 결정하는 구성을 의도했습니다.
