### PR TITLE
프론트엔드 E2E 스모크 범위 확대

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,8 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Landing page smoke test
-        run: npm run e2e -- landing-page.spec.ts
+      - name: Public smoke tests
+        run: npm run e2e -- landing-page.spec.ts home.smoke.spec.ts public-entrypoints.smoke.spec.ts
 
       - name: Upload Playwright report
         if: failure()

--- a/frontend/e2e/public-entrypoints.smoke.spec.ts
+++ b/frontend/e2e/public-entrypoints.smoke.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+test("demo experience starts without login and records a sample encounter", async ({
+  page,
+}) => {
+  await page.goto("/experience");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "로그인 없이 빙고 흐름을 빠르게 체험해 보세요",
+    }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "AI", exact: true }).click();
+  await page.getByRole("button", { name: "디자인", exact: true }).click();
+  await page.getByRole("button", { name: "프로덕트", exact: true }).click();
+  await page.getByRole("button", { name: "데모 빙고 시작" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "보드가 채워지는 흐름을 관찰해 보세요" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "랜덤 유저 만나기" }).click();
+
+  await expect(page.getByText("방금 만난 참가자")).toBeVisible();
+  await expect(page.getByText("만남 기록")).toBeVisible();
+});
+
+test("admin login entrypoint renders Google login guidance", async ({
+  page,
+}) => {
+  await page.goto("/admin");
+
+  await expect(
+    page.getByRole("heading", { name: "Google 계정으로 관리자 로그인" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Google 계정으로 로그인" }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## 요약
- 프론트엔드 E2E smoke 범위를 랜딩 페이지 1개에서 주요 공개 진입점으로 확대했습니다.
- `/experience` 데모 체험과 `/admin` 로그인 진입점 smoke 테스트를 추가했습니다.
- 기존 법적 페이지 smoke도 CI E2E smoke job에서 함께 실행하도록 변경했습니다.

## 변경 내용
- `frontend/e2e/public-entrypoints.smoke.spec.ts` 추가
  - 데모 체험 페이지에서 키워드 선택, 데모 시작, 랜덤 유저 만나기까지 확인
  - 관리자 로그인 진입점에서 Google 로그인 안내 렌더링 확인
- `.github/workflows/ci.yaml`의 `Frontend E2E Smoke` job 실행 범위 확대
  - `landing-page.spec.ts`
  - `home.smoke.spec.ts`
  - `public-entrypoints.smoke.spec.ts`

## 검증
- `npm run lint` 통과
- `npm run build` 통과
- `npm run e2e -- landing-page.spec.ts home.smoke.spec.ts public-entrypoints.smoke.spec.ts` 통과
- `npx prettier --check ../.github/workflows/ci.yaml e2e/public-entrypoints.smoke.spec.ts` 통과

## 참고
- 전체 E2E를 PR 필수로 확대하지 않고, 빠른 공개 진입점 smoke만 추가했습니다.
