### PR TITLE
Dependabot 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    groups:
+      frontend-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    groups:
+      backend-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-patch-and-minor:
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
## 요약
- Dependabot 설정을 추가해 npm, pip, GitHub Actions 의존성 업데이트 PR을 자동 생성하도록 했습니다.
- PR 폭주를 줄이기 위해 patch/minor 업데이트는 ecosystem별 그룹으로 묶었습니다.

## 변경 내용
- `.github/dependabot.yml` 추가
- 업데이트 대상
  - `frontend` npm dependencies
  - `backend` pip requirements
  - GitHub Actions workflow actions
- 매주 월요일 오전, Asia/Seoul 기준으로 순차 실행
- ecosystem별 open PR 최대 5개 제한

## 검증
- `npx prettier --check ../.github/dependabot.yml` 통과
- `npm run lint` 통과

## 참고
- Dependabot security alert 자체는 repository settings 권한 영역이라 이 PR에는 포함하지 않았습니다.
