### PR TITLE
Docker 빌드 검증 워크플로 추가

### DIFF
--- a/.github/workflows/docker-build-check.yaml
+++ b/.github/workflows/docker-build-check.yaml
@@ -1,0 +1,71 @@
+name: Docker Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/docker-build-check.yaml"
+      - "backend/**"
+      - "frontend/**"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-build-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    name: Docker Build (${{ matrix.component }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - component: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        if: matrix.component == 'backend'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=docker-build-check-${{ matrix.component }}
+          cache-to: type=gha,scope=docker-build-check-${{ matrix.component }},mode=max
+
+      - name: Build frontend image
+        if: matrix.component == 'frontend'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          provenance: false
+          sbom: false
+          build-args: |
+            VITE_API_URL=http://127.0.0.1:8000
+            VITE_SUPABASE_URL=http://127.0.0.1:54321
+            VITE_SUPABASE_ANON_KEY=test-anon-key
+            VITE_GOOGLE_CLIENT_ID=test-google-client-id
+          cache-from: type=gha,scope=docker-build-check-${{ matrix.component }}
+          cache-to: type=gha,scope=docker-build-check-${{ matrix.component }},mode=max


### PR DESCRIPTION
## 요약
- PR에서 backend/frontend Docker 이미지가 실제로 빌드되는지 확인하는 workflow를 추가했습니다.
- GHCR push는 하지 않고 `push: false`로 빌드 검증만 수행합니다.

## 변경 내용
- `.github/workflows/docker-build-check.yaml` 추가
- backend/frontend matrix build 구성
- frontend build args는 테스트용 placeholder 값을 사용
- Buildx GHA cache 사용

## 검증
- `npx prettier --check ../.github/workflows/docker-build-check.yaml` 통과
- 로컬 backend Docker build 통과
  - `docker build -f backend/Dockerfile backend`
- 로컬 frontend Docker build 통과
  - `docker build --build-arg ... -f frontend/Dockerfile frontend`

## 참고
- 현재 frontend Dockerfile은 기존처럼 `npm run build:now`를 사용합니다.
- Dockerfile의 typecheck 포함 여부 변경은 배포 이미지 빌드 방식에 영향을 주므로 별도 PR에서 다루는 것이 안전합니다.
