### PR TITLE
데모 체험 E2E 상태 변화 검증 보강

### DIFF
--- a/frontend/e2e/public-entrypoints.smoke.spec.ts
+++ b/frontend/e2e/public-entrypoints.smoke.spec.ts
@@ -19,9 +19,18 @@ test("demo experience starts without login and records a sample encounter", asyn
   await expect(
     page.getByRole("heading", { name: "보드가 채워지는 흐름을 관찰해 보세요" }),
   ).toBeVisible();
+  await expect(page.getByText("아직 만남 기록이 없습니다.")).toBeVisible();
 
   await page.getByRole("button", { name: "랜덤 유저 만나기" }).click();
 
+  await expect(page.getByText("아직 만남 기록이 없습니다.")).toHaveCount(0);
+  await expect(
+    page
+      .locator("div")
+      .filter({ has: page.getByText("만난 사람", { exact: true }) })
+      .filter({ has: page.getByText("1명", { exact: true }) })
+      .first(),
+  ).toBeVisible();
   await expect(page.getByText("방금 만난 참가자")).toBeVisible();
   await expect(page.getByText("만남 기록")).toBeVisible();
 });


### PR DESCRIPTION
## 요약
- 데모 체험 E2E smoke가 실제 상태 변화를 검증하도록 보강했습니다.
- `랜덤 유저 만나기` 클릭 전후의 만남 기록 empty state와 만난 사람 카운트를 확인합니다.

## 변경 내용
- 클릭 전 `아직 만남 기록이 없습니다.` 노출 확인
- 클릭 후 empty state 제거 확인
- 클릭 후 `만난 사람` 지표가 `1명`으로 바뀌는지 확인

## 검증
- `npx prettier --check e2e/public-entrypoints.smoke.spec.ts` 통과
- `npm run e2e -- public-entrypoints.smoke.spec.ts` 통과
- `npm run e2e -- landing-page.spec.ts home.smoke.spec.ts public-entrypoints.smoke.spec.ts` 통과
