### PR TITLE
Dependabot major 업데이트 자동 PR 제외

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
         update-types:
           - patch
           - minor
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: pip
     directory: /backend
@@ -27,6 +31,10 @@ updates:
         update-types:
           - patch
           - minor
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /
@@ -41,3 +49,7 @@ updates:
         update-types:
           - patch
           - minor
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## 요약
- Dependabot이 major 업데이트 PR을 한꺼번에 많이 열지 않도록 설정을 보수적으로 조정했습니다.
- npm, pip, GitHub Actions 모두 기본적으로 patch/minor 업데이트만 자동 PR 대상으로 유지합니다.

## 변경 내용
- `.github/dependabot.yml`에 ecosystem별 major 업데이트 ignore 추가
  - npm: `version-update:semver-major` 제외
  - pip: `version-update:semver-major` 제외
  - GitHub Actions: `version-update:semver-major` 제외

## 배경
- Dependabot 설정 반영 직후 GitHub Actions major 업데이트 PR이 여러 개 열렸습니다.
- 운영 서비스 초기에는 major 업데이트를 자동으로 대량 생성하기보다, patch/minor만 자동화하고 major는 별도 수동 검토로 분리하는 편이 안전합니다.

## 검증
- `npx prettier --check ../.github/dependabot.yml` 통과
- `npm run lint` 통과

## 참고
- 이미 열린 Dependabot major PR들은 이 설정 PR이 머지된 뒤 별도로 닫거나 필요 항목만 검토하면 됩니다.
