### PR TITLE
관리자 이벤트 공유 QR 탭 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.15.4",
         "@supabase/supabase-js": "^2.101.0",
         "prettier": "^3.3.0",
+        "qrcode": "^1.5.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -21,6 +22,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.53.0",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -2027,6 +2029,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.2.47",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
@@ -2444,7 +2456,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2453,7 +2464,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2684,6 +2694,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2846,6 +2865,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
@@ -2858,7 +2888,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2869,8 +2898,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2976,6 +3004,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
@@ -3034,6 +3071,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3080,6 +3123,12 @@
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3543,6 +3592,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3856,6 +3914,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4843,6 +4910,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4900,7 +4976,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5037,6 +5112,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -5252,6 +5336,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5433,6 +5534,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -5568,6 +5684,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5647,6 +5769,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5665,7 +5801,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6427,6 +6562,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -6439,6 +6580,20 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6471,6 +6626,12 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -6488,6 +6649,93 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "^5.15.4",
     "@supabase/supabase-js": "^2.101.0",
     "prettier": "^3.3.0",
+    "qrcode": "^1.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.14.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import {
   AdminEventOverviewPage,
   AdminEventParticipantsPage,
   AdminEventSettingsPage,
+  AdminEventSharePage,
   AdminMembersPage,
   AdminPoliciesPage,
   AdminRoutesLoginPage,
@@ -46,6 +47,7 @@ function AppRoutes() {
             path="/admin/events/:adminEventId/participants"
             element={<AdminEventParticipantsPage />}
           />
+          <Route path="/admin/events/:adminEventId/share" element={<AdminEventSharePage />} />
           <Route path="/admin/policies" element={<AdminPoliciesPage />} />
           <Route path="/event/:eventSlug" element={<Home />} />
           <Route path="/event/:eventSlug/privacy" element={<PublicEventPrivacyPage />} />
@@ -80,6 +82,10 @@ function AppRoutes() {
           />
           <Route
             path="/event/:eventSlug/admin/event-settings/:adminEventId/participants"
+            element={<Navigate to={getAdminPath("event-settings")} replace />}
+          />
+          <Route
+            path="/event/:eventSlug/admin/event-settings/:adminEventId/share"
             element={<Navigate to={getAdminPath("event-settings")} replace />}
           />
           <Route

--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import QRCode from "qrcode";
 import ReactMarkdown from "react-markdown";
 import { useNavigate, useParams } from "react-router-dom";
 import {
@@ -89,7 +90,7 @@ import {
 import { interpolateConsentTemplate } from "../../utils/consentTemplate";
 
 type AdminSection = AdminConsoleSection;
-type EventDetailTab = "overview" | "dashboard" | "participants";
+type EventDetailTab = "overview" | "dashboard" | "participants" | "share";
 
 type EventFormState = {
   id?: number;
@@ -140,6 +141,7 @@ const EVENT_DETAIL_TABS: Array<{ key: EventDetailTab; label: string }> = [
   { key: "overview", label: "개요" },
   { key: "dashboard", label: "대시보드" },
   { key: "participants", label: "참가자" },
+  { key: "share", label: "공유" },
 ];
 const canUseGoogleAdminAuth = () => isSupabaseConfigured();
 const getAdminOAuthRedirectUrl = () => {
@@ -148,6 +150,14 @@ const getAdminOAuthRedirectUrl = () => {
   }
 
   return new URL(getAdminPath(), window.location.origin).toString();
+};
+
+const getAbsolutePublicUrl = (path: string) => {
+  if (typeof window === "undefined") {
+    return path;
+  }
+
+  return new URL(path, window.location.origin).toString();
 };
 const EVENT_KEYWORD_PRESET_OPTIONS = getEventKeywordPresetDefinitions();
 
@@ -587,6 +597,128 @@ const EventProgress = ({
       <div className="whitespace-nowrap text-right">
         <span className="text-xl font-black tracking-tight text-slate-800">{progress}%</span>
         <span className="ml-2 text-sm text-slate-400">({current}/{total})</span>
+      </div>
+    </div>
+  );
+};
+
+const EventQrShareCard = ({
+  eventName,
+  shareUrl,
+}: {
+  eventName: string;
+  shareUrl: string;
+}) => {
+  const [qrDataUrl, setQrDataUrl] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+    setFeedback("");
+    setQrDataUrl("");
+
+    void QRCode.toDataURL(shareUrl, {
+      errorCorrectionLevel: "M",
+      margin: 2,
+      scale: 8,
+      color: {
+        dark: "#0f172a",
+        light: "#ffffff",
+      },
+    })
+      .then((nextDataUrl) => {
+        if (isMounted) {
+          setQrDataUrl(nextDataUrl);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setFeedback("QR 코드를 생성하지 못했습니다. URL을 직접 공유해 주세요.");
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [shareUrl]);
+
+  const handleCopyUrl = async () => {
+    if (!navigator.clipboard) {
+      setFeedback("브라우저에서 클립보드를 지원하지 않습니다. URL을 직접 복사해 주세요.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setFeedback("이벤트 URL을 복사했습니다.");
+    } catch {
+      setFeedback("URL을 복사하지 못했습니다. 직접 선택해 복사해 주세요.");
+    }
+  };
+
+  return (
+    <div className="rounded-[1.5rem] bg-[#f7fbf2] p-6">
+      <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] items-start gap-4 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-5 lg:grid-cols-[16rem_minmax(0,1fr)] lg:gap-6">
+        <div className="flex justify-start">
+          <div className="flex h-[7.5rem] w-[7.5rem] items-center justify-center rounded-[1.25rem] bg-white p-2.5 shadow-[0_16px_40px_rgba(15,23,42,0.08)] ring-1 ring-slate-100 sm:h-40 sm:w-40 sm:p-3 lg:h-64 lg:w-64 lg:rounded-[1.5rem] lg:p-4">
+            {qrDataUrl ? (
+              <img src={qrDataUrl} alt={`${eventName} 참가 QR 코드`} className="h-full w-full" />
+            ) : (
+              <span className="text-sm font-semibold text-slate-400">QR 생성 중</span>
+            )}
+          </div>
+        </div>
+
+        <div className="min-w-0 space-y-5">
+          <div>
+            <p className="text-lg font-black text-brand-700 sm:text-xl">참가 링크 공유</p>
+            <p className="mt-2 text-sm font-semibold leading-6 text-slate-500">
+              현장에서 QR을 바로 보여주거나, 이미지와 URL을 저장해 참가자에게 공유할 수 있습니다.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+              Event URL
+            </p>
+            <code className="block break-all rounded-2xl bg-white px-4 py-3 text-sm font-semibold leading-6 text-brand-700 ring-1 ring-slate-100">
+              {shareUrl}
+            </code>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {qrDataUrl ? (
+              <a
+                href={qrDataUrl}
+                download={`${eventName.replace(/[^a-z0-9가-힣_-]+/gi, "-")}-qr.png`}
+                aria-label={`${eventName} 참가 QR PNG 저장`}
+                className="inline-flex h-10 items-center justify-center rounded-full bg-brand-700 px-5 text-sm font-semibold text-white transition-colors hover:bg-brand-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+              >
+                QR 저장
+              </a>
+            ) : null}
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full px-5"
+              onClick={() => void handleCopyUrl()}
+            >
+              URL 복사
+            </Button>
+          </div>
+
+          {feedback ? (
+            <p className="text-sm font-semibold text-brand-700" role="status" aria-live="polite">
+              {feedback}
+            </p>
+          ) : null}
+
+          <div className="rounded-2xl bg-white px-4 py-3 text-sm font-semibold leading-6 text-slate-500 ring-1 ring-slate-100 max-sm:hidden">
+            <p>· QR은 참가자가 스캔하면 이벤트 홈으로 이동합니다.</p>
+            <p>· 행사장 화면에는 이 탭을 열어 QR을 바로 보여줄 수 있습니다.</p>
+            <p>· 인쇄물이나 안내 메시지에는 QR 저장 또는 URL 복사를 사용하세요.</p>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -1715,6 +1847,9 @@ const AdminConsolePage = ({
   const selectedEventHomePath = selectedEvent
     ? selectedEvent.publicPath || getEventHomePath(selectedEvent.slug)
     : "";
+  const selectedEventShareUrl = selectedEventHomePath
+    ? getAbsolutePublicUrl(selectedEventHomePath)
+    : "";
   const selectedEventTimeRange = selectedEvent
     ? getTimeRangeLabel(selectedEvent.startAt, selectedEvent.endAt)
     : "";
@@ -2307,6 +2442,13 @@ const AdminConsolePage = ({
                           </div>
                         </div>
                       </div>
+                    ) : null}
+
+                    {eventDetailTab === "share" ? (
+                      <EventQrShareCard
+                        eventName={selectedEvent.name}
+                        shareUrl={selectedEventShareUrl}
+                      />
                     ) : null}
 
                     {eventDetailTab === "dashboard" ? (
@@ -3525,5 +3667,8 @@ export const AdminEventDashboardPage = () => (
 );
 export const AdminEventParticipantsPage = () => (
   <AdminConsolePage section="event-settings" eventDetailTab="participants" />
+);
+export const AdminEventSharePage = () => (
+  <AdminConsolePage section="event-settings" eventDetailTab="share" />
 );
 export const AdminPoliciesPage = () => <AdminConsolePage section="policies" />;


### PR DESCRIPTION
## Use This Template When
- 이 PR은 FE 단일 도메인 변경이며, 요청에 따라 리뷰용 PR로 올립니다.

## Summary
- Task ID: admin-event-share-qr

## Impact Trigger (Select At Least One)
- [ ] Cross-domain change (BE/FE/Infra)
- [ ] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [x] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [ ] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [x] docs/reference/design-guide.md (if applicable)
- [x] docs/reference/agent-collaboration.md

## Changes
- 관리자 이벤트 상세에 `공유` 탭을 추가했습니다.
- `/admin/events/:adminEventId/share` 라우트를 추가했습니다.
- 공유 탭에서 QR 이미지를 왼쪽, 참가 링크/액션을 오른쪽에 배치했습니다.
- `QR 저장`, `URL 복사` 액션을 제공합니다.
- QR 생성 실패, 클립보드 미지원/실패 피드백을 표시합니다.
- QR 생성을 위해 `qrcode`, `@types/qrcode` 의존성을 추가했습니다.

## Validation
- Tests: `cd frontend && npm run build`
- Result: 통과
- Not run and reason: E2E는 이번 변경의 최소 검증 범위를 넘어 수동 확인 대상으로 남겼습니다.

## Guide Sync Check
- [x] Updated Korean mirrors for changed English guides — 문서 변경 없음

## Handoff
- [ ] Added handoff note following docs/templates/agent-handoff.md
- 단일 FE 변경이며 PR 본문에 변경/검증 내용을 기록했습니다.
