### PR TITLE
feat(frontend): 관리자 이벤트 관리 UX 개선

### DIFF
--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -34,7 +34,13 @@ import {
 } from "../../config/eventProfiles";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
@@ -63,7 +69,10 @@ import adminTitleIllustration from "../../assets/illustrations/title.svg";
 import type {
   AdminEventManagerRequest,
   AdminEvent,
+  AdminEventBingoRow,
+  AdminEventKeywordRow,
   AdminEventManagerRequestReviewResult,
+  AdminEventParticipant,
   AdminEventStatus,
   AdminMember,
   AdminPolicyTemplate,
@@ -91,6 +100,14 @@ import { interpolateConsentTemplate } from "../../utils/consentTemplate";
 
 type AdminSection = AdminConsoleSection;
 type EventDetailTab = "overview" | "dashboard" | "participants" | "share";
+type SortDirection = "asc" | "desc";
+type SortState<Key extends string> = {
+  key: Key;
+  direction: SortDirection;
+};
+type BingoSortKey = "line" | "count" | "rate";
+type KeywordSortKey = "rank" | "keyword" | "count";
+type ParticipantSortKey = "name" | "email" | "progress" | "keywords";
 
 type EventFormState = {
   id?: number;
@@ -124,10 +141,14 @@ const POLICY_TEMPLATE_OPTIONS: Array<{
   {
     key: "consent_markdown",
     label: "행사 참가자 안내",
-    description: "행사 로그인 전 모달과 /event/:slug/privacy 페이지에 노출됩니다.",
+    description:
+      "행사 로그인 전 모달과 /event/:slug/privacy 페이지에 노출됩니다.",
   },
 ];
-const POLICY_PREVIEW_VARIABLES: Record<AdminPolicyTemplateKey, Record<string, string>> = {
+const POLICY_PREVIEW_VARIABLES: Record<
+  AdminPolicyTemplateKey,
+  Record<string, string>
+> = {
   consent_markdown: {
     eventName: "샘플 네트워킹 데이",
     eventTeam: POLICY_PREVIEW_HOST,
@@ -247,7 +268,9 @@ const getRoleLabel = (role: AdminRole) => {
   return role === "admin" ? "Admin" : "Event Manager";
 };
 
-const getApplicationStatusLabel = (status: AdminEventManagerRequest["status"]) => {
+const getApplicationStatusLabel = (
+  status: AdminEventManagerRequest["status"],
+) => {
   if (status === "approved") {
     return "승인";
   }
@@ -257,7 +280,9 @@ const getApplicationStatusLabel = (status: AdminEventManagerRequest["status"]) =
   return "대기";
 };
 
-const getApplicationStatusClassName = (status: AdminEventManagerRequest["status"]) => {
+const getApplicationStatusClassName = (
+  status: AdminEventManagerRequest["status"],
+) => {
   if (status === "approved") {
     return "bg-brand-100 text-brand-800";
   }
@@ -287,10 +312,113 @@ const sortAdminEvents = (items: AdminEvent[]) => {
 };
 
 const upsertAdminEvent = (items: AdminEvent[], nextItem: AdminEvent) => {
-  return sortAdminEvents([...items.filter((item) => item.id !== nextItem.id), nextItem]);
+  return sortAdminEvents([
+    ...items.filter((item) => item.id !== nextItem.id),
+    nextItem,
+  ]);
 };
 
-const getAdminEventDetailPath = (eventId: number | string, tab: EventDetailTab = "overview") => {
+const compareText = (left: string, right: string) =>
+  left.localeCompare(right, "ko-KR", { numeric: true, sensitivity: "base" });
+
+const applySortDirection = (result: number, direction: SortDirection) =>
+  direction === "asc" ? result : -result;
+
+const getDefaultSortDirection = (key: string): SortDirection =>
+  ["line", "rank", "keyword", "name", "email"].includes(key) ? "asc" : "desc";
+
+const getNextSortDirection = <Key extends string>(
+  previousValue: SortState<Key>,
+  key: Key,
+): SortDirection =>
+  previousValue.key === key
+    ? previousValue.direction === "desc"
+      ? "asc"
+      : "desc"
+    : getDefaultSortDirection(key);
+
+const getBingoLineSortValue = (lineLabel: string) => {
+  const matchedNumber = lineLabel.match(/\d+/);
+  return matchedNumber ? Number(matchedNumber[0]) : Number.MAX_SAFE_INTEGER;
+};
+
+const sortBingoRows = (
+  rows: AdminEventBingoRow[],
+  sortState: SortState<BingoSortKey>,
+) => {
+  return [...rows].sort((left, right) => {
+    let result = 0;
+    if (sortState.key === "line") {
+      result =
+        getBingoLineSortValue(left.lineLabel) -
+          getBingoLineSortValue(right.lineLabel) ||
+        compareText(left.lineLabel, right.lineLabel);
+    }
+    if (sortState.key === "count") {
+      result =
+        left.count - right.count ||
+        compareText(left.lineLabel, right.lineLabel);
+    }
+    if (sortState.key === "rate") {
+      result =
+        left.rate - right.rate || compareText(left.lineLabel, right.lineLabel);
+    }
+
+    return applySortDirection(result, sortState.direction);
+  });
+};
+
+const sortKeywordRows = (
+  rows: AdminEventKeywordRow[],
+  sortState: SortState<KeywordSortKey>,
+) => {
+  return [...rows].sort((left, right) => {
+    let result = 0;
+    if (sortState.key === "rank") {
+      result = left.rank - right.rank;
+    }
+    if (sortState.key === "keyword") {
+      result = compareText(left.keyword, right.keyword);
+    }
+    if (sortState.key === "count") {
+      result = left.count - right.count || left.rank - right.rank;
+    }
+
+    return applySortDirection(result, sortState.direction);
+  });
+};
+
+const sortParticipants = (
+  participants: AdminEventParticipant[],
+  sortState: SortState<ParticipantSortKey>,
+) => {
+  return [...participants].sort((left, right) => {
+    let result = 0;
+    if (sortState.key === "name") {
+      result = compareText(left.name, right.name);
+    }
+    if (sortState.key === "email") {
+      result = compareText(left.email, right.email);
+    }
+    if (sortState.key === "progress") {
+      result =
+        left.progressPercent - right.progressPercent ||
+        compareText(left.name, right.name);
+    }
+    if (sortState.key === "keywords") {
+      result =
+        left.keywords.length - right.keywords.length ||
+        compareText(left.name, right.name);
+    }
+
+    return applySortDirection(result, sortState.direction);
+  });
+};
+
+const getAdminEventDetailPath = (
+  eventId: number | string,
+  tab: EventDetailTab = "overview",
+) => {
   const basePath = `${getAdminPath("event-settings")}/${eventId}`;
   return tab === "overview" ? basePath : `${basePath}/${tab}`;
 };
@@ -312,7 +440,8 @@ const getTimeRangeLabel = (startAt: string, endAt: string) => {
 
     const hour = parts.find((part) => part.type === "hour")?.value ?? "";
     const minute = parts.find((part) => part.type === "minute")?.value ?? "";
-    const dayPeriod = parts.find((part) => part.type === "dayPeriod")?.value ?? "";
+    const dayPeriod =
+      parts.find((part) => part.type === "dayPeriod")?.value ?? "";
 
     return {
       label: `${hour}.${minute}`,
@@ -342,7 +471,10 @@ const formatDurationLabel = (minutes: number) => {
   return `${hours}시간 ${remainingMinutes}분`;
 };
 
-const createEventFormState = (adminEmail: string, eventItem?: AdminEvent): EventFormState => {
+const createEventFormState = (
+  adminEmail: string,
+  eventItem?: AdminEvent,
+): EventFormState => {
   if (eventItem) {
     return {
       id: eventItem.id,
@@ -532,7 +664,7 @@ const AdminBrand = ({ compact = false }: { compact?: boolean }) => {
         alt="Bingo Networking Admin"
         className={cn(
           "mx-auto block h-auto w-[19.25rem] max-w-full",
-          compact && "mx-0 w-[12rem] max-w-[100%]"
+          compact && "mx-0 w-[9.75rem] max-w-[100%]",
         )}
       />
     </div>
@@ -551,8 +683,14 @@ const SectionHeader = ({
   return (
     <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div className="space-y-1">
-        <h1 className="text-3xl font-black tracking-tight text-brand-800">{title}</h1>
-        {description ? <p className="max-w-3xl text-sm leading-6 text-slate-500">{description}</p> : null}
+        <h1 className="text-3xl font-black tracking-tight text-brand-800">
+          {title}
+        </h1>
+        {description ? (
+          <p className="max-w-3xl text-sm leading-6 text-slate-500">
+            {description}
+          </p>
+        ) : null}
       </div>
       {action}
     </div>
@@ -569,7 +707,7 @@ const EventStatusBadge = ({ status }: { status: AdminEventStatus }) => {
         "inline-flex min-w-[4.2rem] items-center justify-center rounded-md px-3 py-1 text-sm font-bold",
         status === "ended" && "bg-slate-600 text-white",
         status === "in_progress" && "bg-brand-500 text-white",
-        status === "scheduled" && "bg-brand-50 text-brand-600"
+        status === "scheduled" && "bg-brand-50 text-brand-600",
       )}
     >
       {label}
@@ -595,12 +733,48 @@ const EventProgress = ({
         />
       </div>
       <div className="whitespace-nowrap text-right">
-        <span className="text-xl font-black tracking-tight text-slate-800">{progress}%</span>
-        <span className="ml-2 text-sm text-slate-400">({current}/{total})</span>
+        <span className="text-xl font-black tracking-tight text-slate-800">
+          {progress}%
+        </span>
+        <span className="ml-2 text-sm text-slate-400">
+          ({current}/{total})
+        </span>
       </div>
     </div>
   );
 };
+
+const SortHeaderButton = ({
+  children,
+  active,
+  direction,
+  onClick,
+  className,
+}: {
+  children: ReactNode;
+  active: boolean;
+  direction: SortDirection;
+  onClick: () => void;
+  className?: string;
+}) => (
+  <button
+    type="button"
+    className={cn(
+      "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-2 py-1 text-left font-black text-brand-700 transition-colors hover:bg-white/70",
+      active &&
+        "bg-white text-slate-900 shadow-[0_8px_20px_rgba(15,23,42,0.06)]",
+      className,
+    )}
+    onClick={onClick}
+  >
+    <span>{children}</span>
+    <span
+      className={cn("text-xs", active ? "text-brand-600" : "text-slate-300")}
+    >
+      {active ? (direction === "asc" ? "↑" : "↓") : "↕"}
+    </span>
+  </button>
+);
 
 const EventQrShareCard = ({
   eventName,
@@ -633,7 +807,9 @@ const EventQrShareCard = ({
       })
       .catch(() => {
         if (isMounted) {
-          setFeedback("QR 코드를 생성하지 못했습니다. URL을 직접 공유해 주세요.");
+          setFeedback(
+            "QR 코드를 생성하지 못했습니다. URL을 직접 공유해 주세요.",
+          );
         }
       });
 
@@ -644,7 +820,9 @@ const EventQrShareCard = ({
 
   const handleCopyUrl = async () => {
     if (!navigator.clipboard) {
-      setFeedback("브라우저에서 클립보드를 지원하지 않습니다. URL을 직접 복사해 주세요.");
+      setFeedback(
+        "브라우저에서 클립보드를 지원하지 않습니다. URL을 직접 복사해 주세요.",
+      );
       return;
     }
 
@@ -657,31 +835,40 @@ const EventQrShareCard = ({
   };
 
   return (
-    <div className="rounded-[1.5rem] bg-[#f7fbf2] p-6">
+    <div className="rounded-[1.5rem] bg-white p-6 shadow-[0_18px_48px_rgba(15,23,42,0.07)] ring-1 ring-slate-100">
       <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] items-start gap-4 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-5 lg:grid-cols-[16rem_minmax(0,1fr)] lg:gap-6">
         <div className="flex justify-start">
-          <div className="flex h-[7.5rem] w-[7.5rem] items-center justify-center rounded-[1.25rem] bg-white p-2.5 shadow-[0_16px_40px_rgba(15,23,42,0.08)] ring-1 ring-slate-100 sm:h-40 sm:w-40 sm:p-3 lg:h-64 lg:w-64 lg:rounded-[1.5rem] lg:p-4">
+          <div className="flex h-[7.5rem] w-[7.5rem] items-center justify-center rounded-[1.25rem] bg-[#f7fbf2] p-2.5 shadow-inner ring-1 ring-brand-100 sm:h-40 sm:w-40 sm:p-3 lg:h-64 lg:w-64 lg:rounded-[1.5rem] lg:p-4">
             {qrDataUrl ? (
-              <img src={qrDataUrl} alt={`${eventName} 참가 QR 코드`} className="h-full w-full" />
+              <img
+                src={qrDataUrl}
+                alt={`${eventName} 참가 QR 코드`}
+                className="h-full w-full"
+              />
             ) : (
-              <span className="text-sm font-semibold text-slate-400">QR 생성 중</span>
+              <span className="text-sm font-semibold text-slate-400">
+                QR 생성 중
+              </span>
             )}
           </div>
         </div>
 
         <div className="min-w-0 space-y-5">
           <div>
-            <p className="text-lg font-black text-brand-700 sm:text-xl">참가 링크 공유</p>
+            <p className="text-xl font-black text-slate-900 sm:text-2xl">
+              참가 링크 공유
+            </p>
             <p className="mt-2 text-sm font-semibold leading-6 text-slate-500">
-              현장에서 QR을 바로 보여주거나, 이미지와 URL을 저장해 참가자에게 공유할 수 있습니다.
+              현장에서 QR을 바로 보여주거나, 이미지와 URL을 저장해 참가자에게
+              공유할 수 있습니다.
             </p>
           </div>
 
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+            <p className="text-xs font-black uppercase tracking-[0.16em] text-slate-400">
               Event URL
             </p>
-            <code className="block break-all rounded-2xl bg-white px-4 py-3 text-sm font-semibold leading-6 text-brand-700 ring-1 ring-slate-100">
+            <code className="block break-all rounded-2xl bg-[#f7fbf2] px-4 py-3 text-sm font-semibold leading-6 text-brand-700 ring-1 ring-brand-100">
               {shareUrl}
             </code>
           </div>
@@ -700,15 +887,28 @@ const EventQrShareCard = ({
             <Button
               type="button"
               variant="outline"
-              className="rounded-full px-5"
+              className="whitespace-nowrap rounded-full px-5"
               onClick={() => void handleCopyUrl()}
             >
               URL 복사
             </Button>
+            <a
+              href={shareUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-10 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-brand-700 bg-white px-5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+            >
+              열어보기
+              <ExternalLinkIcon />
+            </a>
           </div>
 
           {feedback ? (
-            <p className="text-sm font-semibold text-brand-700" role="status" aria-live="polite">
+            <p
+              className="text-sm font-semibold text-brand-700"
+              role="status"
+              aria-live="polite"
+            >
               {feedback}
             </p>
           ) : null}
@@ -716,7 +916,9 @@ const EventQrShareCard = ({
           <div className="rounded-2xl bg-white px-4 py-3 text-sm font-semibold leading-6 text-slate-500 ring-1 ring-slate-100 max-sm:hidden">
             <p>· QR은 참가자가 스캔하면 이벤트 홈으로 이동합니다.</p>
             <p>· 행사장 화면에는 이 탭을 열어 QR을 바로 보여줄 수 있습니다.</p>
-            <p>· 인쇄물이나 안내 메시지에는 QR 저장 또는 URL 복사를 사용하세요.</p>
+            <p>
+              · 인쇄물이나 안내 메시지에는 QR 저장 또는 URL 복사를 사용하세요.
+            </p>
           </div>
         </div>
       </div>
@@ -735,7 +937,7 @@ const EmptyPanelState = ({
     <div
       className={cn(
         "flex min-h-[12rem] items-center justify-center rounded-[1.4rem] border border-dashed border-brand-100 bg-white/70 px-6 text-center text-sm font-semibold leading-6 text-slate-400",
-        className
+        className,
       )}
     >
       {message}
@@ -849,7 +1051,7 @@ const LoginPage = () => {
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : "Google 관리자 로그인 중 오류가 발생했습니다."
+          : "Google 관리자 로그인 중 오류가 발생했습니다.",
       );
     } finally {
       setIsSubmitting(false);
@@ -883,7 +1085,11 @@ const LoginPage = () => {
                     onClick={handleGoogleLogin}
                   >
                     <GoogleLogoIcon />
-                    <span>{isSubmitting ? "Google로 이동 중..." : "Google 계정으로 로그인"}</span>
+                    <span>
+                      {isSubmitting
+                        ? "Google로 이동 중..."
+                        : "Google 계정으로 로그인"}
+                    </span>
                   </Button>
                 </div>
               </div>
@@ -895,14 +1101,17 @@ const LoginPage = () => {
                   Google 관리자 로그인이 필요합니다
                 </h2>
                 <p className="text-sm leading-6 text-amber-800/80">
-                  현재 환경에는 관리자용 Google/Supabase 설정이 없어 로그인할 수 없습니다.
+                  현재 환경에는 관리자용 Google/Supabase 설정이 없어 로그인할 수
+                  없습니다.
                 </p>
               </div>
             </div>
           )}
 
           {errorMessage ? (
-            <p className="text-center text-sm font-semibold text-rose-600">{errorMessage}</p>
+            <p className="text-center text-sm font-semibold text-rose-600">
+              {errorMessage}
+            </p>
           ) : null}
         </div>
       </main>
@@ -926,12 +1135,29 @@ const AdminConsolePage = ({
 
   const [session, setSession] = useState<AdminSession | null>(initialSession);
   const [members, setMembers] = useState<AdminMember[]>([]);
-  const [applications, setApplications] = useState<AdminEventManagerRequest[]>([]);
+  const [applications, setApplications] = useState<AdminEventManagerRequest[]>(
+    [],
+  );
   const [events, setEvents] = useState<AdminEvent[]>([]);
-  const [selectedEventDetail, setSelectedEventDetail] = useState<AdminEvent | null>(null);
+  const [selectedEventDetail, setSelectedEventDetail] =
+    useState<AdminEvent | null>(null);
   const [memberPage, setMemberPage] = useState(1);
   const [eventPage, setEventPage] = useState(1);
   const [participantPage, setParticipantPage] = useState(1);
+  const [bingoSort, setBingoSort] = useState<SortState<BingoSortKey>>({
+    key: "line",
+    direction: "asc",
+  });
+  const [keywordSort, setKeywordSort] = useState<SortState<KeywordSortKey>>({
+    key: "count",
+    direction: "desc",
+  });
+  const [participantSort, setParticipantSort] = useState<
+    SortState<ParticipantSortKey>
+  >({
+    key: "progress",
+    direction: "desc",
+  });
   const [eventSearchQuery, setEventSearchQuery] = useState("");
   const [showAddModal, setShowAddModal] = useState(false);
   const [showEventModal, setShowEventModal] = useState(false);
@@ -957,24 +1183,30 @@ const AdminConsolePage = ({
   const [isPolicyLoading, setIsPolicyLoading] = useState(false);
   const [isPolicySaving, setIsPolicySaving] = useState(false);
   const [deletingMemberId, setDeletingMemberId] = useState<number | null>(null);
-  const [reviewingApplicationId, setReviewingApplicationId] = useState<number | null>(null);
+  const [reviewingApplicationId, setReviewingApplicationId] = useState<
+    number | null
+  >(null);
   const [resettingEventId, setResettingEventId] = useState<number | null>(null);
   const [newAdminForm, setNewAdminForm] = useState({
     email: "",
     name: "",
     role: "admin" as AdminRole,
   });
-  const [selectedKeywordPresetId, setSelectedKeywordPresetId] =
-    useState<EventKeywordPresetId | "">("");
-  const [isKeywordPresetPanelOpen, setIsKeywordPresetPanelOpen] = useState(false);
+  const [selectedKeywordPresetId, setSelectedKeywordPresetId] = useState<
+    EventKeywordPresetId | ""
+  >("");
+  const [isKeywordPresetPanelOpen, setIsKeywordPresetPanelOpen] =
+    useState(false);
   const [isImportEventPanelOpen, setIsImportEventPanelOpen] = useState(false);
   const [importSourceEventId, setImportSourceEventId] = useState("");
-  const [keywordRecommendationNotice, setKeywordRecommendationNotice] = useState("");
-  const [keywordRecommendationError, setKeywordRecommendationError] = useState("");
+  const [keywordRecommendationNotice, setKeywordRecommendationNotice] =
+    useState("");
+  const [keywordRecommendationError, setKeywordRecommendationError] =
+    useState("");
   const isKeywordDraftComposingRef = useRef(false);
   const skipKeywordDraftBlurRef = useRef(false);
   const [eventForm, setEventForm] = useState<EventFormState>(() =>
-    createEventFormState(initialSession?.email ?? "")
+    createEventFormState(initialSession?.email ?? ""),
   );
 
   useEffect(() => {
@@ -1054,9 +1286,11 @@ const AdminConsolePage = ({
     }
 
     const needsEvents = shouldLoadAdminEvents(section) && events.length === 0;
-    const needsMembers = shouldLoadAdminMembers(section, session.role) && members.length === 0;
+    const needsMembers =
+      shouldLoadAdminMembers(section, session.role) && members.length === 0;
     const needsApplications =
-      shouldLoadAdminApplications(section, session.role) && applications.length === 0;
+      shouldLoadAdminApplications(section, session.role) &&
+      applications.length === 0;
 
     if (!needsEvents && !needsMembers && !needsApplications) {
       setIsConsoleLoading(false);
@@ -1070,13 +1304,19 @@ const AdminConsolePage = ({
         setIsConsoleLoading(true);
         setPageError("");
 
-        const [eventItems, memberItems, applicationPayload] = await Promise.all([
-          needsEvents ? getAdminEvents(session.accessToken) : Promise.resolve(null),
-          needsMembers ? getAdminMembers(session.accessToken) : Promise.resolve(null),
-          needsApplications
-            ? getAdminEventManagerRequests(session.accessToken)
-            : Promise.resolve(null),
-        ]);
+        const [eventItems, memberItems, applicationPayload] = await Promise.all(
+          [
+            needsEvents
+              ? getAdminEvents(session.accessToken)
+              : Promise.resolve(null),
+            needsMembers
+              ? getAdminMembers(session.accessToken)
+              : Promise.resolve(null),
+            needsApplications
+              ? getAdminEventManagerRequests(session.accessToken)
+              : Promise.resolve(null),
+          ],
+        );
 
         if (cancelled) {
           return;
@@ -1102,7 +1342,11 @@ const AdminConsolePage = ({
             navigate(getAdminPath(), { replace: true });
             return;
           }
-          setPageError(error instanceof Error ? error.message : "관리자 데이터를 불러오지 못했습니다.");
+          setPageError(
+            error instanceof Error
+              ? error.message
+              : "관리자 데이터를 불러오지 못했습니다.",
+          );
         }
       } finally {
         if (!cancelled) {
@@ -1142,15 +1386,18 @@ const AdminConsolePage = ({
         const templates = await Promise.all(
           POLICY_TEMPLATE_OPTIONS.map(async (option) => ({
             key: option.key,
-            template: await getAdminPolicyTemplate(session.accessToken, option.key),
-          }))
+            template: await getAdminPolicyTemplate(
+              session.accessToken,
+              option.key,
+            ),
+          })),
         );
         if (!cancelled) {
           const nextTemplates = Object.fromEntries(
-            templates.map(({ key, template }) => [key, template])
+            templates.map(({ key, template }) => [key, template]),
           ) as Partial<Record<AdminPolicyTemplateKey, AdminPolicyTemplate>>;
           const nextDrafts = Object.fromEntries(
-            templates.map(({ key, template }) => [key, template.content])
+            templates.map(({ key, template }) => [key, template.content]),
           ) as Partial<Record<AdminPolicyTemplateKey, string>>;
           setPolicyTemplates(nextTemplates);
           setPolicyDrafts(nextDrafts);
@@ -1169,7 +1416,7 @@ const AdminConsolePage = ({
           setPolicyError(
             error instanceof Error
               ? error.message
-              : "개인정보 처리 문안을 불러오지 못했습니다."
+              : "개인정보 처리 문안을 불러오지 못했습니다.",
           );
         }
       } finally {
@@ -1184,7 +1431,13 @@ const AdminConsolePage = ({
     return () => {
       cancelled = true;
     };
-  }, [isSessionBootstrapped, navigate, section, session, shouldUseGoogleAdminAuth]);
+  }, [
+    isSessionBootstrapped,
+    navigate,
+    section,
+    session,
+    shouldUseGoogleAdminAuth,
+  ]);
 
   const visibleMembers = useMemo(() => {
     const startIndex = (memberPage - 1) * ITEMS_PER_PAGE;
@@ -1201,7 +1454,9 @@ const AdminConsolePage = ({
       return (
         eventItem.name.toLowerCase().includes(normalizedQuery) ||
         eventItem.adminEmail.toLowerCase().includes(normalizedQuery) ||
-        formatEventRowDate(eventItem.eventDate).toLowerCase().includes(normalizedQuery)
+        formatEventRowDate(eventItem.eventDate)
+          .toLowerCase()
+          .includes(normalizedQuery)
       );
     });
   }, [eventSearchQuery, events]);
@@ -1216,19 +1471,26 @@ const AdminConsolePage = ({
       return null;
     }
 
-    if (selectedEventDetail && String(selectedEventDetail.id) === adminEventId) {
+    if (
+      selectedEventDetail &&
+      String(selectedEventDetail.id) === adminEventId
+    ) {
       return selectedEventDetail;
     }
 
-    return events.find((eventItem) => String(eventItem.id) === adminEventId) ?? null;
+    return (
+      events.find((eventItem) => String(eventItem.id) === adminEventId) ?? null
+    );
   }, [adminEventId, eventDetailTab, events, selectedEventDetail]);
 
   const featuredEvent = selectedEvent ?? events[0] ?? null;
   const canManageApplications = session?.role === "admin";
   const canEditSelectedEvent = !!selectedEvent?.canEdit;
   const pendingApplicationCount = useMemo(
-    () => applications.filter((requestItem) => requestItem.status === "pending").length,
-    [applications]
+    () =>
+      applications.filter((requestItem) => requestItem.status === "pending")
+        .length,
+    [applications],
   );
 
   const selectedEventInsights = useMemo(() => {
@@ -1242,30 +1504,57 @@ const AdminConsolePage = ({
     };
   }, [selectedEvent]);
 
-  const visibleParticipants = useMemo(() => {
-    if (!selectedEventInsights) {
-      return [];
-    }
+  const sortedBingoRows = useMemo(() => {
+    return selectedEventInsights
+      ? sortBingoRows(selectedEventInsights.bingoRows, bingoSort)
+      : [];
+  }, [bingoSort, selectedEventInsights]);
 
+  const sortedKeywordRows = useMemo(() => {
+    return selectedEventInsights
+      ? sortKeywordRows(selectedEventInsights.keywordRows, keywordSort)
+      : [];
+  }, [keywordSort, selectedEventInsights]);
+
+  const sortedParticipants = useMemo(() => {
+    return selectedEventInsights
+      ? sortParticipants(selectedEventInsights.participants, participantSort)
+      : [];
+  }, [participantSort, selectedEventInsights]);
+
+  const visibleParticipants = useMemo(() => {
     const startIndex = (participantPage - 1) * DETAIL_PARTICIPANTS_PER_PAGE;
-    return selectedEventInsights.participants.slice(
+    return sortedParticipants.slice(
       startIndex,
-      startIndex + DETAIL_PARTICIPANTS_PER_PAGE
+      startIndex + DETAIL_PARTICIPANTS_PER_PAGE,
     );
-  }, [participantPage, selectedEventInsights]);
+  }, [participantPage, sortedParticipants]);
 
   const availableImportEvents = useMemo(() => {
-    return events.filter((eventItem) => eventItem.id !== eventForm.id && eventItem.keywords.length > 0);
+    return events.filter(
+      (eventItem) =>
+        eventItem.id !== eventForm.id && eventItem.keywords.length > 0,
+    );
   }, [eventForm.id, events]);
   const selectedKeywordPreset = useMemo(() => {
-    return EVENT_KEYWORD_PRESET_OPTIONS.find((item) => item.id === selectedKeywordPresetId) ?? null;
+    return (
+      EVENT_KEYWORD_PRESET_OPTIONS.find(
+        (item) => item.id === selectedKeywordPresetId,
+      ) ?? null
+    );
   }, [selectedKeywordPresetId]);
 
-  const memberTotalPages = Math.max(1, Math.ceil(members.length / ITEMS_PER_PAGE));
-  const eventTotalPages = Math.max(1, Math.ceil(filteredEvents.length / ITEMS_PER_PAGE));
+  const memberTotalPages = Math.max(
+    1,
+    Math.ceil(members.length / ITEMS_PER_PAGE),
+  );
+  const eventTotalPages = Math.max(
+    1,
+    Math.ceil(filteredEvents.length / ITEMS_PER_PAGE),
+  );
   const participantTotalPages = Math.max(
     1,
-    Math.ceil((selectedEventInsights?.participants.length ?? 0) / DETAIL_PARTICIPANTS_PER_PAGE)
+    Math.ceil(sortedParticipants.length / DETAIL_PARTICIPANTS_PER_PAGE),
   );
 
   useEffect(() => {
@@ -1299,7 +1588,7 @@ const AdminConsolePage = ({
     }
 
     const hasSelectedEvent = availableImportEvents.some(
-      (eventItem) => String(eventItem.id) === importSourceEventId
+      (eventItem) => String(eventItem.id) === importSourceEventId,
     );
 
     if (!hasSelectedEvent) {
@@ -1314,6 +1603,10 @@ const AdminConsolePage = ({
   useEffect(() => {
     setParticipantPage(1);
   }, [adminEventId, eventDetailTab]);
+
+  useEffect(() => {
+    setParticipantPage(1);
+  }, [participantSort]);
 
   useEffect(() => {
     if (!session || !isSessionBootstrapped || normalizedAdminEventId === null) {
@@ -1331,7 +1624,10 @@ const AdminConsolePage = ({
       try {
         setIsDetailLoading(true);
         setPageError("");
-        const detail = await getAdminEventDetail(session.accessToken, normalizedAdminEventId);
+        const detail = await getAdminEventDetail(
+          session.accessToken,
+          normalizedAdminEventId,
+        );
         if (cancelled) {
           return;
         }
@@ -1349,7 +1645,11 @@ const AdminConsolePage = ({
             navigate(getAdminPath(), { replace: true });
             return;
           }
-          setPageError(error instanceof Error ? error.message : "이벤트 상세를 불러오지 못했습니다.");
+          setPageError(
+            error instanceof Error
+              ? error.message
+              : "이벤트 상세를 불러오지 못했습니다.",
+          );
         }
       } finally {
         if (!cancelled) {
@@ -1373,13 +1673,19 @@ const AdminConsolePage = ({
   ]);
 
   useEffect(() => {
-    if (session?.role === "event_manager" && (section === "members" || section === "applications")) {
+    if (
+      session?.role === "event_manager" &&
+      (section === "members" || section === "applications")
+    ) {
       navigate(getAdminPath("event-settings"), { replace: true });
     }
   }, [navigate, section, session?.role]);
 
   const goToSection = (nextSection: AdminSection) => {
-    if ((nextSection === "members" || nextSection === "applications") && session?.role !== "admin") {
+    if (
+      (nextSection === "members" || nextSection === "applications") &&
+      session?.role !== "admin"
+    ) {
       navigate(getAdminPath("event-settings"));
       return;
     }
@@ -1391,12 +1697,36 @@ const AdminConsolePage = ({
     navigate(getAdminPath(nextSection));
   };
 
-  const goToEventDetail = (eventId: number, tab: EventDetailTab = "overview") => {
+  const goToEventDetail = (
+    eventId: number,
+    tab: EventDetailTab = "overview",
+  ) => {
     navigate(getAdminEventDetailPath(eventId, tab));
   };
 
   const goBackToEventList = () => {
     navigate(getAdminPath("event-settings"));
+  };
+
+  const toggleBingoSort = (key: BingoSortKey) => {
+    setBingoSort((previousValue) => ({
+      key,
+      direction: getNextSortDirection(previousValue, key),
+    }));
+  };
+
+  const toggleKeywordSort = (key: KeywordSortKey) => {
+    setKeywordSort((previousValue) => ({
+      key,
+      direction: getNextSortDirection(previousValue, key),
+    }));
+  };
+
+  const toggleParticipantSort = (key: ParticipantSortKey) => {
+    setParticipantSort((previousValue) => ({
+      key,
+      direction: getNextSortDirection(previousValue, key),
+    }));
   };
 
   const handleLogout = async () => {
@@ -1446,7 +1776,7 @@ const AdminConsolePage = ({
 
       const nextKeywords = clampKeywordList(
         [...previousValue.keywords, normalizedKeyword],
-        previousValue.boardSize
+        previousValue.boardSize,
       );
 
       return {
@@ -1457,7 +1787,9 @@ const AdminConsolePage = ({
     });
   };
 
-  const handleKeywordDraftKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeywordDraftKeyDown = (
+    event: KeyboardEvent<HTMLInputElement>,
+  ) => {
     if (isKeywordDraftComposingRef.current || event.nativeEvent.isComposing) {
       return;
     }
@@ -1472,14 +1804,16 @@ const AdminConsolePage = ({
   };
 
   const handleApplyKeywordPreset = (presetId: EventKeywordPresetId) => {
-    const selectedPreset = EVENT_KEYWORD_PRESET_OPTIONS.find((item) => item.id === presetId);
+    const selectedPreset = EVENT_KEYWORD_PRESET_OPTIONS.find(
+      (item) => item.id === presetId,
+    );
     if (!selectedPreset) {
       return;
     }
 
     if (eventForm.keywords.length > 0 && selectedKeywordPresetId !== presetId) {
       const confirmed = window.confirm(
-        `현재 키워드를 "${selectedPreset.label}" 카테고리 키워드로 바꿀까요?`
+        `현재 키워드를 "${selectedPreset.label}" 카테고리 키워드로 바꿀까요?`,
       );
       if (!confirmed) {
         return;
@@ -1488,18 +1822,23 @@ const AdminConsolePage = ({
 
     setSelectedKeywordPresetId(presetId);
     setIsKeywordPresetPanelOpen(false);
-    setKeywordRecommendationNotice(`"${selectedPreset.label}" 카테고리 키워드를 적용했습니다.`);
+    setKeywordRecommendationNotice(
+      `"${selectedPreset.label}" 카테고리 키워드를 적용했습니다.`,
+    );
     setKeywordRecommendationError("");
     setEventForm((previousValue) => ({
       ...previousValue,
-      keywords: buildEventKeywordPresetKeywords(presetId, previousValue.boardSize),
+      keywords: buildEventKeywordPresetKeywords(
+        presetId,
+        previousValue.boardSize,
+      ),
       keywordDraft: "",
     }));
   };
 
   const handleImportKeywordsFromEvent = () => {
     const sourceEvent = availableImportEvents.find(
-      (eventItem) => String(eventItem.id) === importSourceEventId
+      (eventItem) => String(eventItem.id) === importSourceEventId,
     );
 
     if (!sourceEvent) {
@@ -1510,7 +1849,7 @@ const AdminConsolePage = ({
 
     if (eventForm.keywords.length > 0) {
       const confirmed = window.confirm(
-        `현재 키워드를 "${sourceEvent.name}" 행사 키워드로 바꿀까요?`
+        `현재 키워드를 "${sourceEvent.name}" 행사 키워드로 바꿀까요?`,
       );
       if (!confirmed) {
         return;
@@ -1524,7 +1863,9 @@ const AdminConsolePage = ({
       keywordDraft: "",
     }));
     setKeywordRecommendationError("");
-    setKeywordRecommendationNotice(`"${sourceEvent.name}" 행사 키워드를 가져왔습니다.`);
+    setKeywordRecommendationNotice(
+      `"${sourceEvent.name}" 행사 키워드를 가져왔습니다.`,
+    );
     setIsImportEventPanelOpen(false);
   };
 
@@ -1563,7 +1904,11 @@ const AdminConsolePage = ({
         role: "admin",
       });
     } catch (error) {
-      setAddFormError(error instanceof Error ? error.message : "관리자를 추가하지 못했습니다.");
+      setAddFormError(
+        error instanceof Error
+          ? error.message
+          : "관리자를 추가하지 못했습니다.",
+      );
     }
   };
 
@@ -1578,7 +1923,7 @@ const AdminConsolePage = ({
     }
 
     const isConfirmed = window.confirm(
-      `${member.name} (${member.email}) 계정을 삭제할까요?`
+      `${member.name} (${member.email}) 계정을 삭제할까요?`,
     );
     if (!isConfirmed) {
       return;
@@ -1588,9 +1933,15 @@ const AdminConsolePage = ({
       setDeletingMemberId(member.id);
       setPageError("");
       await deleteAdminMember(session.accessToken, member.id);
-      setMembers((previousValue) => previousValue.filter((item) => item.id !== member.id));
+      setMembers((previousValue) =>
+        previousValue.filter((item) => item.id !== member.id),
+      );
     } catch (error) {
-      setPageError(error instanceof Error ? error.message : "관리자 계정을 삭제하지 못했습니다.");
+      setPageError(
+        error instanceof Error
+          ? error.message
+          : "관리자 계정을 삭제하지 못했습니다.",
+      );
     } finally {
       setDeletingMemberId(null);
     }
@@ -1598,14 +1949,14 @@ const AdminConsolePage = ({
 
   const handleReviewApplication = async (
     request: AdminEventManagerRequest,
-    nextStatus: "approved" | "rejected"
+    nextStatus: "approved" | "rejected",
   ) => {
     if (!session || session.role !== "admin") {
       return;
     }
 
     const confirmed = window.confirm(
-      `${request.name}님의 신청을 ${nextStatus === "approved" ? "승인" : "반려"}할까요?`
+      `${request.name}님의 신청을 ${nextStatus === "approved" ? "승인" : "반려"}할까요?`,
     );
     if (!confirmed) {
       return;
@@ -1614,20 +1965,27 @@ const AdminConsolePage = ({
     try {
       setReviewingApplicationId(request.id);
       setPageError("");
-      const reviewResult = await reviewAdminEventManagerRequest(session.accessToken, request.id, {
-        status: nextStatus,
-      });
+      const reviewResult = await reviewAdminEventManagerRequest(
+        session.accessToken,
+        request.id,
+        {
+          status: nextStatus,
+        },
+      );
       setApplications((previousValue) =>
-        [...previousValue.map((item) => (item.id === reviewResult.request.id ? reviewResult.request : item))].sort(
-          (left, right) => {
-            const priority = (value: AdminEventManagerRequest["status"]) =>
-              value === "pending" ? 0 : value === "approved" ? 1 : 2;
-            return (
-              priority(left.status) - priority(right.status) ||
-              new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
-            );
-          }
-        )
+        [
+          ...previousValue.map((item) =>
+            item.id === reviewResult.request.id ? reviewResult.request : item,
+          ),
+        ].sort((left, right) => {
+          const priority = (value: AdminEventManagerRequest["status"]) =>
+            value === "pending" ? 0 : value === "approved" ? 1 : 2;
+          return (
+            priority(left.status) - priority(right.status) ||
+            new Date(right.createdAt).getTime() -
+              new Date(left.createdAt).getTime()
+          );
+        }),
       );
       if (nextStatus === "approved") {
         setInviteReviewResult(reviewResult);
@@ -1638,7 +1996,11 @@ const AdminConsolePage = ({
       }
       contentScrollRef.current?.scrollTo({ top: 0, behavior: "smooth" });
     } catch (error) {
-      setPageError(error instanceof Error ? error.message : "신청 상태를 바꾸지 못했습니다.");
+      setPageError(
+        error instanceof Error
+          ? error.message
+          : "신청 상태를 바꾸지 못했습니다.",
+      );
       setPageNotice("");
       setInviteReviewResult(null);
     } finally {
@@ -1652,7 +2014,7 @@ const AdminConsolePage = ({
     }
 
     const isConfirmed = window.confirm(
-      "이 행사에 연결된 참가자, 팀, 빙고판, 교환 기록을 초기화할까요?\n이 작업은 되돌릴 수 없습니다."
+      "이 행사에 연결된 참가자, 팀, 빙고판, 교환 기록을 초기화할까요?\n이 작업은 되돌릴 수 없습니다.",
     );
     if (!isConfirmed) {
       return;
@@ -1662,7 +2024,10 @@ const AdminConsolePage = ({
       setResettingEventId(selectedEvent.id);
       setPageError("");
 
-      const result = await resetAdminEventData(session.accessToken, selectedEvent.id);
+      const result = await resetAdminEventData(
+        session.accessToken,
+        selectedEvent.id,
+      );
       const [nextEvents, nextDetail] = await Promise.all([
         getAdminEvents(session.accessToken),
         getAdminEventDetail(session.accessToken, selectedEvent.id),
@@ -1675,10 +2040,14 @@ const AdminConsolePage = ({
       window.alert(
         stats
           ? `초기화 완료\n참가자 ${stats.deleted_attendees}명, 보드 ${stats.deleted_boards}개, 교환 ${stats.deleted_interactions}건을 삭제했습니다.`
-          : "이벤트 데이터를 초기화했습니다."
+          : "이벤트 데이터를 초기화했습니다.",
       );
     } catch (error) {
-      setPageError(error instanceof Error ? error.message : "이벤트 데이터를 초기화하지 못했습니다.");
+      setPageError(
+        error instanceof Error
+          ? error.message
+          : "이벤트 데이터를 초기화하지 못했습니다.",
+      );
     } finally {
       setResettingEventId(null);
     }
@@ -1708,10 +2077,13 @@ const AdminConsolePage = ({
     try {
       setIsPolicySaving(true);
       setPolicyError("");
-      const savedTemplate = await updateAdminPolicyTemplate(session.accessToken, {
-        templateKey: selectedPolicyKey,
-        content: nextContent,
-      });
+      const savedTemplate = await updateAdminPolicyTemplate(
+        session.accessToken,
+        {
+          templateKey: selectedPolicyKey,
+          content: nextContent,
+        },
+      );
       setPolicyTemplates((currentTemplates) => ({
         ...currentTemplates,
         [selectedPolicyKey]: savedTemplate,
@@ -1725,7 +2097,7 @@ const AdminConsolePage = ({
       setPolicyError(
         error instanceof Error
           ? error.message
-          : "개인정보 처리 문안을 저장하지 못했습니다."
+          : "개인정보 처리 문안을 저장하지 못했습니다.",
       );
       setPolicyNotice("");
     } finally {
@@ -1765,7 +2137,10 @@ const AdminConsolePage = ({
       return;
     }
 
-    const startAt = combineDateAndTimeToIso(eventForm.date, eventForm.startTime);
+    const startAt = combineDateAndTimeToIso(
+      eventForm.date,
+      eventForm.startTime,
+    );
     const endAt = combineDateAndTimeToIso(eventForm.date, eventForm.endTime);
 
     if (new Date(endAt).getTime() <= new Date(startAt).getTime()) {
@@ -1773,7 +2148,11 @@ const AdminConsolePage = ({
       return;
     }
 
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(eventForm.adminEmail.trim().toLowerCase())) {
+    if (
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+        eventForm.adminEmail.trim().toLowerCase(),
+      )
+    ) {
       setEventFormError("행사 문의 이메일을 확인해 주세요.");
       return;
     }
@@ -1785,17 +2164,18 @@ const AdminConsolePage = ({
 
     const keywordsForSave = buildAutoFilledKeywordList(
       eventForm.keywords,
-      eventForm.boardSize
+      eventForm.boardSize,
     );
 
     if (keywordAutofillSummary.missingCount > 0) {
-      const firstGeneratedKeyword = keywordAutofillSummary.generatedKeywords[0] ?? "키워드";
+      const firstGeneratedKeyword =
+        keywordAutofillSummary.generatedKeywords[0] ?? "키워드";
       const confirmed = window.confirm(
         [
           `현재 입력한 키워드는 ${keywordAutofillSummary.currentCount}개입니다.`,
           `${Number(eventForm.boardSize)}x${Number(eventForm.boardSize)} 행사에는 ${keywordAutofillSummary.goalCount}개가 필요합니다.`,
           `부족한 ${keywordAutofillSummary.missingCount}개는 "${firstGeneratedKeyword}"부터 자동으로 채워 저장할까요?`,
-        ].join("\n")
+        ].join("\n"),
       );
 
       if (!confirmed) {
@@ -1837,7 +2217,9 @@ const AdminConsolePage = ({
         navigate(getAdminEventDetailPath(savedEvent.id), { replace: true });
       }
     } catch (error) {
-      setEventFormError(error instanceof Error ? error.message : "행사를 저장하지 못했습니다.");
+      setEventFormError(
+        error instanceof Error ? error.message : "행사를 저장하지 못했습니다.",
+      );
     }
   };
 
@@ -1855,18 +2237,23 @@ const AdminConsolePage = ({
     : "";
   const keywordAutofillSummary = describeKeywordAutofill(
     eventForm.keywords,
-    eventForm.boardSize
+    eventForm.boardSize,
   );
   const canEditPolicyTemplate = session?.role === "admin";
   const activePolicyTemplate = policyTemplates[selectedPolicyKey] ?? null;
   const policyDraft = policyDrafts[selectedPolicyKey] ?? "";
   const selectedPolicyOption =
-    POLICY_TEMPLATE_OPTIONS.find((option) => option.key === selectedPolicyKey) ??
-    POLICY_TEMPLATE_OPTIONS[0];
+    POLICY_TEMPLATE_OPTIONS.find(
+      (option) => option.key === selectedPolicyKey,
+    ) ?? POLICY_TEMPLATE_OPTIONS[0];
   const hasPolicyChanges =
-    activePolicyTemplate !== null && policyDraft.trim() !== activePolicyTemplate.content.trim();
+    activePolicyTemplate !== null &&
+    policyDraft.trim() !== activePolicyTemplate.content.trim();
   const policyPreviewContent = useMemo(() => {
-    return interpolateConsentTemplate(policyDraft, POLICY_PREVIEW_VARIABLES[selectedPolicyKey]);
+    return interpolateConsentTemplate(
+      policyDraft,
+      POLICY_PREVIEW_VARIABLES[selectedPolicyKey],
+    );
   }, [policyDraft, selectedPolicyKey]);
 
   if (!session) {
@@ -1882,51 +2269,79 @@ const AdminConsolePage = ({
   }
 
   return (
-    <div className="min-h-screen bg-brand-500 lg:grid lg:grid-cols-[19rem_minmax(0,1fr)] xl:grid-cols-[21rem_minmax(0,1fr)]">
-      <aside className="flex flex-col justify-between gap-8 px-4 py-7 text-white lg:px-5 lg:py-8">
+    <div className="min-h-screen bg-brand-500 lg:grid lg:grid-cols-[16rem_minmax(0,1fr)] xl:grid-cols-[17rem_minmax(0,1fr)]">
+      <aside className="sticky top-0 z-30 flex flex-col gap-3 bg-brand-500 px-4 py-3 text-white shadow-[0_12px_32px_rgba(15,23,42,0.16)] lg:static lg:justify-between lg:gap-6 lg:px-4 lg:py-7 lg:shadow-none">
         <div>
-          <AdminBrand compact />
+          <div className="flex items-center justify-between gap-3 lg:block">
+            <AdminBrand compact />
+            <Button
+              variant="ghost"
+              className="h-auto shrink-0 px-0 py-0 text-xs font-bold text-white hover:bg-transparent hover:text-white/90 lg:hidden"
+              onClick={() => void handleLogout()}
+            >
+              <LogoutIcon />
+              <span>로그아웃</span>
+            </Button>
+          </div>
 
-          <div className="my-7 h-px bg-white/25" />
+          <div className="my-3 h-px bg-white/20 lg:my-5 lg:bg-white/25" />
 
-          <nav className="grid gap-2" aria-label="admin navigation">
+          <nav
+            className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1 [scrollbar-width:none] lg:mx-0 lg:grid lg:overflow-visible lg:px-0 lg:pb-0"
+            aria-label="admin navigation"
+          >
             {navigationItems
               .filter(({ adminOnly }) => !adminOnly || session.role === "admin")
               .map(({ key, label, Icon }) => (
-              <Button
-                key={key}
-                variant="ghost"
-                className={cn(
-                  "h-auto w-full justify-start rounded-2xl px-5 py-4 text-left text-[1.05rem] font-bold text-white/90 hover:bg-white/15 hover:text-white",
-                  section === key && "bg-white/30 text-brand-900 hover:bg-white/30"
-                )}
-                onClick={() => goToSection(key)}
-              >
-                <span className="flex items-center gap-3">
-                  <Icon />
-                  <span>{label}</span>
-                  {key === "applications" && pendingApplicationCount > 0 ? (
-                    <span className="inline-flex min-w-[1.75rem] items-center justify-center rounded-full bg-white px-2 py-0.5 text-xs font-black text-brand-700">
-                      {pendingApplicationCount}
-                    </span>
-                  ) : null}
-                </span>
-              </Button>
-            ))}
+                <Button
+                  key={key}
+                  variant="ghost"
+                  className={cn(
+                    "h-auto shrink-0 justify-start rounded-full px-3.5 py-2.5 text-left text-sm font-bold text-white/90 hover:bg-white/15 hover:text-white lg:w-full lg:rounded-2xl lg:py-3 lg:text-[0.95rem]",
+                    section === key &&
+                      "bg-white/30 text-brand-900 hover:bg-white/30",
+                  )}
+                  onClick={() => goToSection(key)}
+                >
+                  <span className="flex items-center gap-2.5">
+                    <Icon />
+                    <span>{label}</span>
+                    {key === "applications" && pendingApplicationCount > 0 ? (
+                      <span className="inline-flex min-w-[1.75rem] items-center justify-center rounded-full bg-white px-2 py-0.5 text-xs font-black text-brand-700">
+                        {pendingApplicationCount}
+                      </span>
+                    ) : null}
+                  </span>
+                </Button>
+              ))}
+            <a
+              href="/"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-auto shrink-0 items-center justify-start gap-2.5 rounded-full px-3.5 py-2.5 text-sm font-bold text-white/80 ring-1 ring-white/20 transition-colors hover:bg-white/15 hover:text-white lg:mt-2 lg:w-full lg:rounded-2xl lg:py-3 lg:text-[0.95rem]"
+            >
+              <ExternalLinkIcon />
+              <span>서비스 홈</span>
+            </a>
           </nav>
         </div>
 
-        <div className="flex w-full flex-col items-center gap-2 pb-2 text-center">
-          <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-white/65 text-xl font-black text-slate-500">
+        <div className="hidden w-full flex-col items-center gap-1.5 pb-1 text-center lg:flex">
+          <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/65 text-base font-black text-slate-500">
             {session.name.trim().charAt(0)}
           </span>
-          <p className="text-sm font-medium text-white/95">{session.email}</p>
-          <Badge variant={session.role === "admin" ? "default" : "destructive"} className="min-w-[3.5rem] justify-center bg-slate-900 px-2 py-1 text-[0.72rem] font-semibold">
+          <p className="max-w-full truncate text-xs font-medium text-white/95">
+            {session.email}
+          </p>
+          <Badge
+            variant={session.role === "admin" ? "default" : "destructive"}
+            className="min-w-[3.25rem] justify-center bg-slate-900 px-2 py-1 text-[0.68rem] font-semibold"
+          >
             {getRoleLabel(session.role)}
           </Badge>
           <Button
             variant="ghost"
-            className="mt-1 h-auto px-0 py-0 text-sm font-bold text-white hover:bg-transparent hover:text-white/90"
+            className="mt-1 h-auto px-0 py-0 text-xs font-bold text-white hover:bg-transparent hover:text-white/90"
             onClick={() => void handleLogout()}
           >
             <LogoutIcon />
@@ -1935,10 +2350,13 @@ const AdminConsolePage = ({
         </div>
       </aside>
 
-      <main className="p-5 sm:p-7 lg:p-9 xl:p-10">
-        <Card className="flex h-[calc(100vh-4rem)] flex-col overflow-hidden rounded-[2rem] border-white/40 shadow-soft xl:h-[calc(100vh-6rem)]">
+      <main className="p-3 sm:p-5 lg:p-9 xl:p-10">
+        <Card className="flex min-h-[calc(100vh-7.5rem)] flex-col overflow-hidden rounded-[1.4rem] border-white/40 shadow-soft sm:rounded-[2rem] lg:h-[calc(100vh-4rem)] xl:h-[calc(100vh-6rem)]">
           <CardContent className="min-h-0 flex-1 p-0">
-            <div ref={contentScrollRef} className="min-h-0 h-full overflow-y-auto space-y-8 p-6 pt-6 pr-5 sm:p-8 sm:pt-8 sm:pr-6 md:p-9 md:pt-9 md:pr-7 xl:p-10 xl:pt-10 xl:pr-8 [scrollbar-gutter:stable_both-edges]">
+            <div
+              ref={contentScrollRef}
+              className="min-h-0 h-full overflow-y-auto space-y-6 p-4 pr-3 sm:space-y-8 sm:p-8 sm:pr-6 md:p-9 md:pr-7 xl:p-10 xl:pr-8 [scrollbar-gutter:stable_both-edges]"
+            >
               {pageError ? (
                 <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
                   {pageError}
@@ -1950,330 +2368,220 @@ const AdminConsolePage = ({
                 </div>
               ) : null}
 
-            {section === "dashboard" ? (
-              <>
-                <SectionHeader
-                  title="대시보드"
-                  description="이벤트 현황과 현재 라우팅, 관리자 구성, 빙고 설정을 한 화면에서 빠르게 확인할 수 있습니다."
-                />
+              {section === "dashboard" ? (
+                <>
+                  <SectionHeader
+                    title="대시보드"
+                    description="이벤트 현황과 현재 라우팅, 관리자 구성, 빙고 설정을 한 화면에서 빠르게 확인할 수 있습니다."
+                  />
 
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-                  {[
-                    {
-                      label: "대표 이벤트",
-                      value: featuredEvent ? featuredEvent.name : "이벤트 없음",
-                    },
-                    {
-                      label: "관리자 수",
-                      value: `${members.length}명`,
-                    },
-                    {
-                      label: "총 이벤트 수",
-                      value: `${events.length}개`,
-                    },
-                    {
-                      label: "진행/예정 행사 수",
-                      value: `${events.filter((eventItem) => eventItem.status !== "ended").length}개`,
-                    },
-                    ...(canManageApplications
-                      ? [
-                          {
-                            label: "승인 대기 신청",
-                            value: `${pendingApplicationCount}건`,
-                          },
-                        ]
-                      : []),
-                  ].map((item) => (
-                    <Card
-                      key={item.label}
-                      className="rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none"
-                    >
-                      <CardContent className="flex min-h-[7.9rem] flex-col justify-between gap-4 px-6 pb-6 pt-7">
-                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                          {item.label}
-                        </p>
-                        <p className="text-[1.45rem] font-black tracking-tight leading-tight text-slate-900 xl:text-[1.6rem]">
-                          {item.value}
-                        </p>
+                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                    {[
+                      {
+                        label: "대표 이벤트",
+                        value: featuredEvent
+                          ? featuredEvent.name
+                          : "이벤트 없음",
+                      },
+                      {
+                        label: "관리자 수",
+                        value: `${members.length}명`,
+                      },
+                      {
+                        label: "총 이벤트 수",
+                        value: `${events.length}개`,
+                      },
+                      {
+                        label: "진행/예정 행사 수",
+                        value: `${events.filter((eventItem) => eventItem.status !== "ended").length}개`,
+                      },
+                      ...(canManageApplications
+                        ? [
+                            {
+                              label: "승인 대기 신청",
+                              value: `${pendingApplicationCount}건`,
+                            },
+                          ]
+                        : []),
+                    ].map((item) => (
+                      <Card
+                        key={item.label}
+                        className="rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none"
+                      >
+                        <CardContent className="flex min-h-[7.9rem] flex-col justify-between gap-4 px-6 pb-6 pt-7">
+                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                            {item.label}
+                          </p>
+                          <p className="text-[1.45rem] font-black tracking-tight leading-tight text-slate-900 xl:text-[1.6rem]">
+                            {item.value}
+                          </p>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+
+                  <div className="grid gap-4 xl:grid-cols-[1.05fr_0.95fr]">
+                    <Card className="rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
+                      <CardHeader className="space-y-2 p-7 pb-0">
+                        <CardTitle>이벤트 개요</CardTitle>
+                        <CardDescription>
+                          대표 이벤트의 핵심 운영 정보를 빠르게 확인할 수
+                          있습니다.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="grid gap-4 p-7 pt-6">
+                        {featuredEvent ? (
+                          [
+                            ["행사명", featuredEvent.name],
+                            ["Event team", featuredEvent.eventTeam],
+                            ["행사 위치", featuredEvent.location],
+                            [
+                              "행사 일정",
+                              `${formatEventDateLabel(featuredEvent.startAt)} - ${formatTimeText(featuredEvent.endAt)}`,
+                            ],
+                            ["담당 관리자", featuredEvent.adminEmail],
+                            [
+                              "빙고 크기",
+                              `${featuredEvent.boardSize}X${featuredEvent.boardSize}`,
+                            ],
+                            [
+                              "성공 조건",
+                              `${featuredEvent.bingoMissionCount}줄`,
+                            ],
+                          ].map(([label, value]) => (
+                            <div
+                              key={label}
+                              className="grid gap-2 rounded-[1.4rem] border border-white/90 bg-white/90 px-4 py-4"
+                            >
+                              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                                {label}
+                              </p>
+                              <p className="text-sm font-semibold leading-6 text-slate-700">
+                                {value}
+                              </p>
+                            </div>
+                          ))
+                        ) : (
+                          <EmptyPanelState
+                            className="min-h-[16rem]"
+                            message="아직 등록된 이벤트가 없습니다."
+                          />
+                        )}
                       </CardContent>
                     </Card>
-                  ))}
-                </div>
 
-                <div className="grid gap-4 xl:grid-cols-[1.05fr_0.95fr]">
-                  <Card className="rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
-                    <CardHeader className="space-y-2 p-7 pb-0">
-                      <CardTitle>이벤트 개요</CardTitle>
-                      <CardDescription>대표 이벤트의 핵심 운영 정보를 빠르게 확인할 수 있습니다.</CardDescription>
-                    </CardHeader>
-                    <CardContent className="grid gap-4 p-7 pt-6">
-                      {featuredEvent ? (
-                        [
-                          ["행사명", featuredEvent.name],
-                          ["Event team", featuredEvent.eventTeam],
-                          ["행사 위치", featuredEvent.location],
-                          ["행사 일정", `${formatEventDateLabel(featuredEvent.startAt)} - ${formatTimeText(featuredEvent.endAt)}`],
-                          ["담당 관리자", featuredEvent.adminEmail],
-                          ["빙고 크기", `${featuredEvent.boardSize}X${featuredEvent.boardSize}`],
-                          ["성공 조건", `${featuredEvent.bingoMissionCount}줄`],
+                    <Card className="rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
+                      <CardHeader className="space-y-2 p-7 pb-0">
+                        <CardTitle>라우팅 안내</CardTitle>
+                        <CardDescription>
+                          관리자 URL은 고정되고, 이벤트 페이지는{" "}
+                          <code>/event/{"{token}"}</code> 형식을 사용합니다.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="space-y-4 p-7 pt-6">
+                        {[
+                          [
+                            "이벤트 홈",
+                            featuredEvent
+                              ? getEventHomePath(featuredEvent.slug)
+                              : "/event/{token}",
+                          ],
+                          ["관리자 로그인", getAdminPath()],
+                          ["이벤트 관리", getAdminPath("event-settings")],
                         ].map(([label, value]) => (
                           <div
                             key={label}
-                            className="grid gap-2 rounded-[1.4rem] border border-white/90 bg-white/90 px-4 py-4"
+                            className="space-y-2 rounded-[1.4rem] border border-white/90 bg-white/90 px-4 py-4"
                           >
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                            <p className="text-sm font-semibold text-slate-500">
                               {label}
                             </p>
-                            <p className="text-sm font-semibold leading-6 text-slate-700">{value}</p>
+                            <code className="block break-all rounded-2xl bg-brand-50 px-4 py-3 text-sm font-semibold leading-6 text-brand-700">
+                              {value}
+                            </code>
                           </div>
-                        ))
-                      ) : (
-                        <EmptyPanelState
-                          className="min-h-[16rem]"
-                          message="아직 등록된 이벤트가 없습니다."
-                        />
-                      )}
-                    </CardContent>
-                  </Card>
-
-                  <Card className="rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
-                    <CardHeader className="space-y-2 p-7 pb-0">
-                      <CardTitle>라우팅 안내</CardTitle>
-                      <CardDescription>
-                        관리자 URL은 고정되고, 이벤트 페이지는 <code>/event/{"{token}"}</code> 형식을 사용합니다.
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-4 p-7 pt-6">
-                      {[
-                        ["이벤트 홈", featuredEvent ? getEventHomePath(featuredEvent.slug) : "/event/{token}"],
-                        ["관리자 로그인", getAdminPath()],
-                        ["이벤트 관리", getAdminPath("event-settings")],
-                      ].map(([label, value]) => (
-                        <div
-                          key={label}
-                          className="space-y-2 rounded-[1.4rem] border border-white/90 bg-white/90 px-4 py-4"
-                        >
-                          <p className="text-sm font-semibold text-slate-500">{label}</p>
-                          <code className="block break-all rounded-2xl bg-brand-50 px-4 py-3 text-sm font-semibold leading-6 text-brand-700">
-                            {value}
-                          </code>
-                        </div>
-                      ))}
-                    </CardContent>
-                  </Card>
-                </div>
-              </>
-            ) : null}
-
-            {section === "members" ? (
-              <>
-                <SectionHeader
-                  title="관리자"
-                  action={
-                    <Button className="rounded-full px-5" onClick={() => setShowAddModal(true)}>
-                      관리자 추가
-                      <PlusIcon />
-                    </Button>
-                  }
-                />
-
-                <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-[#fbfcf8]">
-                  <div className="overflow-x-auto">
-                    <Table className="min-w-[760px]">
-                      <TableHeader className="bg-[#f6f8ef]">
-                        <TableRow className="border-none hover:bg-transparent">
-                          <TableHead>번호</TableHead>
-                          <TableHead>이름</TableHead>
-                          <TableHead>계정</TableHead>
-                          <TableHead>전화번호</TableHead>
-                          <TableHead>생성일</TableHead>
-                          <TableHead>권한</TableHead>
-                          <TableHead className="text-left">관리</TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {visibleMembers.map((member) => (
-                          <TableRow key={member.id}>
-                            <TableCell className="font-bold text-slate-900">{member.id}</TableCell>
-                            <TableCell className="font-semibold text-slate-800">{member.name}</TableCell>
-                            <TableCell>{member.email}</TableCell>
-                            <TableCell>{member.phone}</TableCell>
-                            <TableCell>{formatAdminDate(member.createdAt)}</TableCell>
-                            <TableCell>
-                              <Badge variant={member.role === "admin" ? "default" : "destructive"}>
-                                {getRoleLabel(member.role)}
-                              </Badge>
-                            </TableCell>
-                            <TableCell className="text-left">
-                              {member.id === session.id ? (
-                                <span className="text-xs font-semibold text-slate-400">보호됨</span>
-                              ) : (
-                                <div className="flex justify-start">
-                                  <Button
-                                    variant="ghost"
-                                    className="h-9 rounded-full px-4 text-rose-600 hover:bg-rose-50 hover:text-rose-700"
-                                    disabled={deletingMemberId === member.id}
-                                    onClick={() => void handleDeleteMember(member)}
-                                  >
-                                    {deletingMemberId === member.id ? "삭제 중" : "삭제"}
-                                  </Button>
-                                </div>
-                              )}
-                            </TableCell>
-                          </TableRow>
                         ))}
-                      </TableBody>
-                    </Table>
+                      </CardContent>
+                    </Card>
                   </div>
-                </div>
+                </>
+              ) : null}
 
-                <div className="flex justify-center gap-2">
-                  {Array.from({ length: memberTotalPages }, (_, index) => index + 1).map((pageNumber) => (
-                    <Button
-                      key={pageNumber}
-                      variant={memberPage === pageNumber ? "secondary" : "ghost"}
-                      size="icon"
-                      className="rounded-full"
-                      onClick={() => setMemberPage(pageNumber)}
-                    >
-                      {pageNumber}
-                    </Button>
-                  ))}
-                </div>
-              </>
-            ) : null}
+              {section === "members" ? (
+                <>
+                  <SectionHeader
+                    title="관리자"
+                    action={
+                      <Button
+                        className="rounded-full px-5"
+                        onClick={() => setShowAddModal(true)}
+                      >
+                        관리자 추가
+                        <PlusIcon />
+                      </Button>
+                    }
+                  />
 
-            {section === "applications" ? (
-              <>
-                <SectionHeader
-                  title="신청 관리"
-                  description="이벤트 관리자 권한 요청을 검토하고 승인 상태를 관리합니다."
-                  action={
-                    <div className="self-start rounded-full bg-brand-100 px-4 py-2 text-sm font-bold text-brand-800 md:self-auto">
-                      승인 대기 {pendingApplicationCount}건
-                    </div>
-                  }
-                />
-
-                {pageNotice ? (
-                  <div className="rounded-2xl border border-brand-100 bg-brand-50 px-4 py-4 text-sm font-semibold text-brand-800">
-                    <p>{pageNotice}</p>
-                    {inviteReviewResult ? (
-                      <div className="mt-3 space-y-2 rounded-2xl bg-white px-4 py-3 text-xs font-semibold leading-6 text-brand-700">
-                        <p>
-                          {inviteReviewResult.invitedAdmin
-                            ? `권한 부여 계정: ${inviteReviewResult.invitedAdmin.email}`
-                            : "기존 관리자 계정 권한을 유지합니다."}
-                        </p>
-                        <p>
-                          {inviteReviewResult.inviteEmailSent
-                            ? "승인 안내 메일 발송 완료 · 승인된 이메일로 Google 로그인하면 관리자 페이지에 접속할 수 있습니다."
-                            : "메일 발송에 실패했거나 설정이 없어 수동 안내가 필요합니다. 승인된 이메일로 Google 로그인하면 관리자 페이지에 접속할 수 있습니다."}
-                        </p>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
-
-                {applications.length > 0 ? (
                   <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-[#fbfcf8]">
                     <div className="overflow-x-auto">
-                      <Table className="min-w-[1060px]">
+                      <Table className="min-w-[760px]">
                         <TableHeader className="bg-[#f6f8ef]">
                           <TableRow className="border-none hover:bg-transparent">
-                            <TableHead>신청일</TableHead>
-                            <TableHead>신청자</TableHead>
-                            <TableHead>행사명</TableHead>
-                            <TableHead>행사 목적</TableHead>
-                            <TableHead>예상 일정</TableHead>
-                            <TableHead className="w-[8rem] min-w-[8rem] whitespace-nowrap">
-                              상태
-                            </TableHead>
-                            <TableHead className="w-[13rem] text-center">관리</TableHead>
+                            <TableHead>번호</TableHead>
+                            <TableHead>이름</TableHead>
+                            <TableHead>계정</TableHead>
+                            <TableHead>전화번호</TableHead>
+                            <TableHead>생성일</TableHead>
+                            <TableHead>권한</TableHead>
+                            <TableHead className="text-left">관리</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
-                          {applications.map((requestItem) => (
-                            <TableRow key={requestItem.id}>
-                              <TableCell className="whitespace-nowrap text-sm text-slate-500">
-                                {formatAdminDate(requestItem.createdAt)}
+                          {visibleMembers.map((member) => (
+                            <TableRow key={member.id}>
+                              <TableCell className="font-bold text-slate-900">
+                                {member.id}
                               </TableCell>
-                              <TableCell className="min-w-[10rem]">
-                                <div className="space-y-1">
-                                  <p className="font-semibold text-slate-900">{requestItem.name}</p>
-                                  <p className="text-sm text-slate-500">{requestItem.email}</p>
-                                  {requestItem.organization ? (
-                                    <p className="text-xs font-semibold text-brand-700">
-                                      {requestItem.organization}
-                                    </p>
-                                  ) : null}
-                                </div>
+                              <TableCell className="font-semibold text-slate-800">
+                                {member.name}
                               </TableCell>
-                              <TableCell className="min-w-[11rem] font-semibold text-slate-800 break-words">
-                                {requestItem.eventName}
+                              <TableCell>{member.email}</TableCell>
+                              <TableCell>{member.phone}</TableCell>
+                              <TableCell>
+                                {formatAdminDate(member.createdAt)}
                               </TableCell>
-                              <TableCell className="min-w-[14rem] text-sm leading-6 text-slate-600">
-                                {requestItem.eventPurpose.length > 110
-                                  ? `${requestItem.eventPurpose.slice(0, 110)}...`
-                                  : requestItem.eventPurpose}
+                              <TableCell>
+                                <Badge
+                                  variant={
+                                    member.role === "admin"
+                                      ? "default"
+                                      : "destructive"
+                                  }
+                                >
+                                  {getRoleLabel(member.role)}
+                                </Badge>
                               </TableCell>
-                              <TableCell className="whitespace-nowrap text-sm text-slate-500">
-                                {requestItem.expectedEventDate
-                                  ? formatAdminDate(requestItem.expectedEventDate)
-                                  : "미정"}
-                                {requestItem.expectedAttendeeCount ? (
-                                  <p className="mt-1 text-xs font-semibold text-brand-700">
-                                    예상 {requestItem.expectedAttendeeCount}명
-                                  </p>
-                                ) : null}
-                              </TableCell>
-                              <TableCell className="w-[8rem] min-w-[8rem] whitespace-nowrap">
-                                <div className="space-y-2">
-                                  <span
-                                    className={`inline-flex whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ${getApplicationStatusClassName(requestItem.status)}`}
-                                  >
-                                    {getApplicationStatusLabel(requestItem.status)}
+                              <TableCell className="text-left">
+                                {member.id === session.id ? (
+                                  <span className="text-xs font-semibold text-slate-400">
+                                    보호됨
                                   </span>
-                                  {requestItem.reviewedByName ? (
-                                    <p className="text-xs text-slate-400">
-                                      {requestItem.reviewedByName}
-                                      {requestItem.reviewedAt
-                                        ? ` · ${formatAdminDate(requestItem.reviewedAt)}`
-                                        : ""}
-                                    </p>
-                                  ) : null}
-                                </div>
-                              </TableCell>
-                              <TableCell className="w-[13rem] text-center">
-                                <div className="flex justify-center gap-2">
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="min-w-[4.75rem] whitespace-nowrap rounded-full px-4"
-                                    disabled={
-                                      requestItem.status !== "pending" ||
-                                      reviewingApplicationId === requestItem.id
-                                    }
-                                    onClick={() => void handleReviewApplication(requestItem, "approved")}
-                                  >
-                                    {reviewingApplicationId === requestItem.id &&
-                                    requestItem.status === "pending"
-                                      ? "처리 중"
-                                      : "승인"}
-                                  </Button>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    className="min-w-[4.75rem] whitespace-nowrap rounded-full px-4 text-rose-600 hover:bg-rose-50 hover:text-rose-700"
-                                    disabled={
-                                      requestItem.status !== "pending" ||
-                                      reviewingApplicationId === requestItem.id
-                                    }
-                                    onClick={() => void handleReviewApplication(requestItem, "rejected")}
-                                  >
-                                    반려
-                                  </Button>
-                                </div>
+                                ) : (
+                                  <div className="flex justify-start">
+                                    <Button
+                                      variant="ghost"
+                                      className="h-9 rounded-full px-4 text-rose-600 hover:bg-rose-50 hover:text-rose-700"
+                                      disabled={deletingMemberId === member.id}
+                                      onClick={() =>
+                                        void handleDeleteMember(member)
+                                      }
+                                    >
+                                      {deletingMemberId === member.id
+                                        ? "삭제 중"
+                                        : "삭제"}
+                                    </Button>
+                                  </div>
+                                )}
                               </TableCell>
                             </TableRow>
                           ))}
@@ -2281,115 +2589,280 @@ const AdminConsolePage = ({
                       </Table>
                     </div>
                   </div>
-                ) : (
-                  <EmptyPanelState
-                    className="min-h-[18rem]"
-                    message="아직 접수된 이벤트 관리자 신청이 없습니다."
+
+                  <div className="flex justify-center gap-2">
+                    {Array.from(
+                      { length: memberTotalPages },
+                      (_, index) => index + 1,
+                    ).map((pageNumber) => (
+                      <Button
+                        key={pageNumber}
+                        variant={
+                          memberPage === pageNumber ? "secondary" : "ghost"
+                        }
+                        size="icon"
+                        className="rounded-full"
+                        onClick={() => setMemberPage(pageNumber)}
+                      >
+                        {pageNumber}
+                      </Button>
+                    ))}
+                  </div>
+                </>
+              ) : null}
+
+              {section === "applications" ? (
+                <>
+                  <SectionHeader
+                    title="신청 관리"
+                    description="이벤트 관리자 권한 요청을 검토하고 승인 상태를 관리합니다."
+                    action={
+                      <div className="self-start rounded-full bg-brand-100 px-4 py-2 text-sm font-bold text-brand-800 md:self-auto">
+                        승인 대기 {pendingApplicationCount}건
+                      </div>
+                    }
                   />
-                )}
-              </>
-            ) : null}
 
-            {section === "event-settings" ? (
-              eventDetailTab ? (
-                selectedEvent ? (
-                  <div className="space-y-8">
-                    <div className="space-y-5">
-                      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                        <div className="space-y-1">
-                          <p className="text-sm font-bold text-slate-300">이벤트 관리</p>
-                          <div className="flex items-center gap-3">
-                            <button
-                              type="button"
-                              className="inline-flex h-10 w-10 items-center justify-center rounded-full text-brand-700 hover:bg-brand-50"
-                              aria-label="이벤트 목록으로 돌아가기"
-                              onClick={goBackToEventList}
-                            >
-                              <ChevronLeftIcon />
-                            </button>
-                            <h1 className="text-[2.1rem] font-black tracking-tight text-brand-800">
-                              {selectedEvent.name}
-                            </h1>
-                          </div>
+                  {pageNotice ? (
+                    <div className="rounded-2xl border border-brand-100 bg-brand-50 px-4 py-4 text-sm font-semibold text-brand-800">
+                      <p>{pageNotice}</p>
+                      {inviteReviewResult ? (
+                        <div className="mt-3 space-y-2 rounded-2xl bg-white px-4 py-3 text-xs font-semibold leading-6 text-brand-700">
+                          <p>
+                            {inviteReviewResult.invitedAdmin
+                              ? `권한 부여 계정: ${inviteReviewResult.invitedAdmin.email}`
+                              : "기존 관리자 계정 권한을 유지합니다."}
+                          </p>
+                          <p>
+                            {inviteReviewResult.inviteEmailSent
+                              ? "승인 안내 메일 발송 완료 · 승인된 이메일로 Google 로그인하면 관리자 페이지에 접속할 수 있습니다."
+                              : "메일 발송에 실패했거나 설정이 없어 수동 안내가 필요합니다. 승인된 이메일로 Google 로그인하면 관리자 페이지에 접속할 수 있습니다."}
+                          </p>
                         </div>
-
-                        <div className="flex flex-wrap items-center gap-3">
-                          {!canEditSelectedEvent ? (
-                            <span className="rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500">
-                              읽기 전용
-                            </span>
-                          ) : null}
-                          <a
-                            href={selectedEventHomePath}
-                            target="_blank"
-                            rel="noreferrer"
-                            title={selectedEventHomePath}
-                            className="inline-flex h-11 items-center justify-center gap-2 rounded-full border border-brand-700 bg-white px-5 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
-                          >
-                            이벤트 홈
-                            <ExternalLinkIcon />
-                          </a>
-                          {canEditSelectedEvent ? (
-                            <>
-                              <Button
-                                variant="destructive"
-                                className="rounded-full px-5"
-                                disabled={resettingEventId === selectedEvent.id}
-                                onClick={() => void handleResetEventData()}
-                              >
-                                {resettingEventId === selectedEvent.id ? "초기화 중" : "데이터 초기화"}
-                              </Button>
-                              <Button
-                                className="rounded-full px-5"
-                                onClick={() => openEventModal(selectedEvent)}
-                              >
-                                행사 수정
-                              </Button>
-                            </>
-                          ) : null}
-                        </div>
-                      </div>
-
-                      <div className="border-b border-slate-200">
-                        <div className="flex flex-wrap gap-4 sm:gap-12">
-                          {EVENT_DETAIL_TABS.map((tabItem) => (
-                            <button
-                              key={tabItem.key}
-                              type="button"
-                              className={cn(
-                                "border-b-[3px] px-2 pb-5 text-base font-semibold text-slate-400 transition-colors",
-                                eventDetailTab === tabItem.key
-                                  ? "border-brand-400 text-slate-900"
-                                  : "border-transparent hover:text-slate-700"
-                              )}
-                              onClick={() => goToEventDetail(selectedEvent.id, tabItem.key)}
-                            >
-                              {tabItem.label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
+                      ) : null}
                     </div>
+                  ) : null}
 
-                    {eventDetailTab === "overview" ? (
-                      <div className="grid gap-5 xl:grid-cols-[1fr_1fr]">
-                        <div className="rounded-[1.5rem] bg-[#f7fbf2] p-6">
-                          <div className="mb-6 text-center text-base font-black text-brand-700">
-                            행사 정보
+                  {applications.length > 0 ? (
+                    <div className="space-y-3">
+                      {applications.map((requestItem) => (
+                        <article
+                          key={requestItem.id}
+                          className="grid gap-4 rounded-[1.35rem] bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.05)] ring-1 ring-slate-100 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,1.4fr)_10rem_10.5rem] xl:items-center"
+                        >
+                          <div className="min-w-0 space-y-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span
+                                className={`inline-flex whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ${getApplicationStatusClassName(requestItem.status)}`}
+                              >
+                                {getApplicationStatusLabel(requestItem.status)}
+                              </span>
+                              <span className="text-xs font-semibold text-slate-400">
+                                {formatAdminDate(requestItem.createdAt)}
+                              </span>
+                            </div>
+                            <div>
+                              <p className="truncate text-base font-black text-slate-900">
+                                {requestItem.eventName}
+                              </p>
+                              <p className="mt-1 text-sm font-semibold text-slate-500">
+                                {requestItem.name} · {requestItem.email}
+                              </p>
+                              {requestItem.organization ? (
+                                <p className="mt-1 text-xs font-bold text-brand-700">
+                                  {requestItem.organization}
+                                </p>
+                              ) : null}
+                            </div>
                           </div>
-                          <div className="flex flex-col gap-5 md:flex-row md:items-center">
-                            <div className="shrink-0 rounded-[1.25rem] bg-white px-4 py-4 shadow-[0_12px_32px_rgba(15,23,42,0.06)] ring-1 ring-slate-100 max-md:w-full md:w-[8.5rem]">
-                              <div className="flex items-center justify-between gap-4 md:flex-col md:justify-center md:gap-3">
+
+                          <div className="min-w-0 rounded-2xl bg-[#f7fbf2] px-4 py-3">
+                            <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
+                              행사 목적
+                            </p>
+                            <p className="mt-2 line-clamp-2 text-sm font-semibold leading-6 text-slate-600">
+                              {requestItem.eventPurpose}
+                            </p>
+                          </div>
+
+                          <div className="text-sm font-semibold text-slate-500">
+                            <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
+                              예상 일정
+                            </p>
+                            <p className="mt-2 whitespace-nowrap">
+                              {requestItem.expectedEventDate
+                                ? formatAdminDate(requestItem.expectedEventDate)
+                                : "미정"}
+                            </p>
+                            {requestItem.expectedAttendeeCount ? (
+                              <p className="mt-1 text-xs font-bold text-brand-700">
+                                예상 {requestItem.expectedAttendeeCount}명
+                              </p>
+                            ) : null}
+                            {requestItem.reviewedByName ? (
+                              <p className="mt-2 text-xs text-slate-400">
+                                {requestItem.reviewedByName}
+                                {requestItem.reviewedAt
+                                  ? ` · ${formatAdminDate(requestItem.reviewedAt)}`
+                                  : ""}
+                              </p>
+                            ) : null}
+                          </div>
+
+                          <div className="flex gap-2 xl:justify-end">
+                            <Button
+                              size="sm"
+                              className="min-w-[4.5rem] whitespace-nowrap rounded-full px-4"
+                              disabled={
+                                requestItem.status !== "pending" ||
+                                reviewingApplicationId === requestItem.id
+                              }
+                              onClick={() =>
+                                void handleReviewApplication(
+                                  requestItem,
+                                  "approved",
+                                )
+                              }
+                            >
+                              {reviewingApplicationId === requestItem.id &&
+                              requestItem.status === "pending"
+                                ? "처리 중"
+                                : "승인"}
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="min-w-[4.5rem] whitespace-nowrap rounded-full border-rose-100 px-4 text-rose-500 hover:bg-rose-50 hover:text-rose-600"
+                              disabled={
+                                requestItem.status !== "pending" ||
+                                reviewingApplicationId === requestItem.id
+                              }
+                              onClick={() =>
+                                void handleReviewApplication(
+                                  requestItem,
+                                  "rejected",
+                                )
+                              }
+                            >
+                              반려
+                            </Button>
+                          </div>
+                        </article>
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyPanelState
+                      className="min-h-[18rem]"
+                      message="아직 접수된 이벤트 관리자 신청이 없습니다."
+                    />
+                  )}
+                </>
+              ) : null}
+
+              {section === "event-settings" ? (
+                eventDetailTab ? (
+                  selectedEvent ? (
+                    <div className="space-y-8">
+                      <div className="space-y-5">
+                        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                          <div className="space-y-1">
+                            <p className="text-sm font-bold text-slate-300">
+                              이벤트 관리
+                            </p>
+                            <div className="flex items-center gap-3">
+                              <button
+                                type="button"
+                                className="inline-flex h-10 w-10 items-center justify-center rounded-full text-brand-700 hover:bg-brand-50"
+                                aria-label="이벤트 목록으로 돌아가기"
+                                onClick={goBackToEventList}
+                              >
+                                <ChevronLeftIcon />
+                              </button>
+                              <h1 className="text-[1.85rem] font-black leading-tight tracking-tight text-brand-800 sm:text-[2rem]">
+                                {selectedEvent.name}
+                              </h1>
+                            </div>
+                          </div>
+
+                          <div className="flex flex-wrap items-center justify-start gap-2 lg:justify-end">
+                            {!canEditSelectedEvent ? (
+                              <span className="rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500">
+                                읽기 전용
+                              </span>
+                            ) : null}
+                            <a
+                              href={selectedEventHomePath}
+                              target="_blank"
+                              rel="noreferrer"
+                              title={selectedEventHomePath}
+                              className="inline-flex h-10 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-600 transition-colors hover:border-brand-200 hover:bg-brand-50 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+                            >
+                              이벤트 홈
+                              <ExternalLinkIcon />
+                            </a>
+                            {canEditSelectedEvent ? (
+                              <>
+                                <Button
+                                  className="h-10 rounded-full px-5 shadow-[0_10px_24px_rgba(15,23,42,0.12)]"
+                                  onClick={() => openEventModal(selectedEvent)}
+                                >
+                                  행사 수정
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  className="h-10 rounded-full border-rose-100 bg-white px-4 text-sm font-semibold text-rose-500 hover:bg-rose-50 hover:text-rose-600"
+                                  disabled={
+                                    resettingEventId === selectedEvent.id
+                                  }
+                                  onClick={() => void handleResetEventData()}
+                                >
+                                  {resettingEventId === selectedEvent.id
+                                    ? "초기화 중"
+                                    : "데이터 초기화"}
+                                </Button>
+                              </>
+                            ) : null}
+                          </div>
+                        </div>
+
+                        <div className="border-b border-slate-200">
+                          <div className="flex flex-wrap gap-3 sm:gap-8">
+                            {EVENT_DETAIL_TABS.map((tabItem) => (
+                              <button
+                                key={tabItem.key}
+                                type="button"
+                                className={cn(
+                                  "border-b-[3px] px-2 pb-4 text-sm font-bold text-slate-400 transition-colors",
+                                  eventDetailTab === tabItem.key
+                                    ? "border-brand-400 text-slate-900"
+                                    : "border-transparent hover:text-slate-700",
+                                )}
+                                onClick={() =>
+                                  goToEventDetail(selectedEvent.id, tabItem.key)
+                                }
+                              >
+                                {tabItem.label}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+
+                      {eventDetailTab === "overview" ? (
+                        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+                          <div className="rounded-[1.75rem] bg-white p-6 shadow-[0_18px_48px_rgba(15,23,42,0.07)] ring-1 ring-slate-100">
+                            <div className="flex flex-col gap-6 md:flex-row md:items-stretch">
+                              <div className="flex shrink-0 items-center justify-between rounded-[1.35rem] bg-[#f7fbf2] px-5 py-4 ring-1 ring-brand-100 md:w-[10rem] md:flex-col md:justify-center">
                                 <div className="flex flex-wrap items-center gap-2 md:justify-center">
-                                  <span className="whitespace-nowrap rounded-full bg-slate-100 px-2.5 py-1 text-[0.7rem] font-bold text-slate-500">
+                                  <span className="whitespace-nowrap rounded-full bg-white px-2.5 py-1 text-[0.7rem] font-bold text-slate-500">
                                     {selectedEventDateParts?.yearLabel}
                                   </span>
                                   <span className="whitespace-nowrap rounded-full bg-brand-100 px-2.5 py-1 text-[0.7rem] font-bold text-brand-700">
                                     {selectedEventDateParts?.monthLabel}
                                   </span>
                                 </div>
-                                <div className="text-right md:text-center">
-                                  <div className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl">
+                                <div className="text-right md:mt-5 md:text-center">
+                                  <div className="text-5xl font-black tracking-tight text-slate-900 sm:text-6xl">
                                     {selectedEventDateParts?.day}
                                   </div>
                                   <div className="mt-1 text-xs font-bold uppercase tracking-[0.28em] text-slate-400">
@@ -2397,723 +2870,1022 @@ const AdminConsolePage = ({
                                   </div>
                                 </div>
                               </div>
-                            </div>
 
-                            <div className="flex-1">
-                              <p className="text-lg font-semibold text-slate-300">
-                                {selectedEventTimeRange}
-                              </p>
-                              <p className="mt-1 text-[2rem] font-black tracking-tight text-slate-900">
-                                {selectedEvent.name}
-                              </p>
-                              <div className="mt-3 flex flex-wrap gap-2">
-                                <span className="rounded-full bg-white px-3 py-1 text-sm font-semibold text-brand-700">
-                                  {selectedEvent.eventTeam}
-                                </span>
-                                <span className="rounded-full bg-white px-3 py-1 text-sm font-semibold text-slate-600">
-                                  {selectedEvent.location}
-                                </span>
-                              </div>
-                            </div>
-
-                            <div className="self-start md:self-center">
-                              <EventStatusBadge status={selectedEvent.status} />
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="rounded-[1.5rem] bg-[#f7fbf2] p-6">
-                          <div className="mb-6 flex items-center justify-center gap-3 text-base font-black text-brand-700">
-                            <span>빙고 정보</span>
-                            <span className="rounded-full bg-white px-3 py-1 text-sm font-black text-brand-700">
-                              {selectedEvent.boardSize}X{selectedEvent.boardSize}
-                            </span>
-                          </div>
-
-                          <div className="flex flex-wrap gap-3">
-                            {selectedEvent.keywords.map((keyword) => (
-                              <span
-                                key={keyword}
-                                className="rounded-xl bg-brand-100 px-4 py-2 text-base font-semibold text-brand-700"
-                              >
-                                {keyword}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    ) : null}
-
-                    {eventDetailTab === "share" ? (
-                      <EventQrShareCard
-                        eventName={selectedEvent.name}
-                        shareUrl={selectedEventShareUrl}
-                      />
-                    ) : null}
-
-                    {eventDetailTab === "dashboard" ? (
-                      selectedEventInsights ? (
-                      <div className="space-y-7">
-                        <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
-                          {[
-                            {
-                              label: "참여자 수",
-                              value: selectedEvent.participantCount.toLocaleString("en-US"),
-                              unit: "명",
-                            },
-                            {
-                              label: "총 키워드 교환 횟수",
-                              value: selectedEventInsights.totalKeywordSelections.toLocaleString("en-US"),
-                              unit: "회",
-                            },
-                            {
-                              label: "리뷰 참여자",
-                              value: selectedEventInsights.reviewParticipants.toLocaleString("en-US"),
-                              unit: "명",
-                            },
-                            {
-                              label: "리뷰 평균 점수",
-                              value: selectedEventInsights.averageReviewScore.toFixed(1),
-                              unit: "/5",
-                            },
-                            {
-                              label: "리뷰 참여율",
-                              value: selectedEventInsights.participationRate.toFixed(1),
-                              unit: "%",
-                            },
-                            {
-                              label: "운영 시간",
-                              value: formatDurationLabel(selectedEventInsights.operatingMinutes),
-                            },
-                          ].map((metricItem) => (
-                            <div
-                              key={metricItem.label}
-                              className="rounded-[1.5rem] bg-[#f7fbf2] px-6 py-7"
-                            >
-                              <p className="text-sm font-black text-brand-700">
-                                {metricItem.label}
-                              </p>
-                              <div className="mt-8 flex items-end gap-2">
-                                <span className="text-[2.2rem] font-black tracking-tight text-slate-900">
-                                  {metricItem.value}
-                                </span>
-                                {metricItem.unit ? (
-                                  <span className="pb-1 text-xl font-black text-brand-700">
-                                    {metricItem.unit}
-                                  </span>
-                                ) : null}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-
-                        <div className="grid gap-5 xl:grid-cols-2">
-                          <div className="flex h-[24rem] flex-col rounded-[1.6rem] bg-[#f7fbf2] p-6">
-                            <div className="text-center text-base font-black text-brand-700">
-                              빙고 정보
-                            </div>
-                            <div className="mt-7 grid grid-cols-[1.2fr_0.8fr_0.7fr] gap-x-4 border-b border-white/80 pb-3">
-                              <p className="text-lg font-black text-brand-700">달성 줄 수</p>
-                              <p className="text-lg font-black text-brand-700">인원 수</p>
-                              <p className="text-lg font-black text-brand-700">비율</p>
-                            </div>
-                            {selectedEventInsights.bingoRows.length > 0 ? (
-                              <div className="-mr-2 mt-4 flex-1 overflow-y-auto pr-4 [scrollbar-gutter:stable_both-edges]">
-                                <div className="grid grid-cols-[1.2fr_0.8fr_0.7fr] gap-x-4 gap-y-4 pb-1">
-                                  {selectedEventInsights.bingoRows.map((bingoRow) => (
-                                    <Fragment key={bingoRow.lineLabel}>
-                                      <div className="flex items-center gap-3 text-base leading-6 text-slate-600">
-                                        <span>{bingoRow.lineLabel}</span>
-                                        {bingoRow.isComplete ? (
-                                          <span className="rounded-full bg-brand-300 px-3 py-1 text-xs font-bold text-white">
-                                            빙고 완성
-                                          </span>
-                                        ) : null}
-                                      </div>
-                                      <p className="text-base text-slate-600">
-                                        {bingoRow.count.toLocaleString("en-US")}명
-                                      </p>
-                                      <p className="text-base text-slate-600">{bingoRow.rate}%</p>
-                                    </Fragment>
-                                  ))}
-                                </div>
-                              </div>
-                            ) : (
-                              <EmptyPanelState
-                                className="mt-4 flex-1"
-                                message="아직 집계된 빙고 데이터가 없습니다."
-                              />
-                            )}
-                          </div>
-
-                          <div className="flex h-[24rem] flex-col rounded-[1.6rem] bg-[#f7fbf2] p-6">
-                            <div className="text-center text-base font-black text-brand-700">
-                              키워드 별 선택 횟수
-                            </div>
-                            <div className="mt-7 grid grid-cols-[0.6fr_1.5fr_1fr] gap-x-4 border-b border-white/80 pb-3">
-                              <p className="text-lg font-black text-brand-700">순위</p>
-                              <p className="text-lg font-black text-brand-700">키워드</p>
-                              <p className="text-lg font-black text-brand-700">선택한 사람 수</p>
-                            </div>
-                            {selectedEventInsights.keywordRows.length > 0 ? (
-                              <div className="-mr-2 mt-4 flex-1 overflow-y-auto pr-4 [scrollbar-gutter:stable_both-edges]">
-                                <div className="grid grid-cols-[0.6fr_1.5fr_1fr] gap-x-4 gap-y-4 pb-1">
-                                  {selectedEventInsights.keywordRows.map((keywordRow) => (
-                                    <Fragment key={keywordRow.keyword}>
-                                      <p className="text-base text-slate-600">
-                                        {keywordRow.rank}
-                                      </p>
-                                      <p className="break-words text-base leading-6 text-slate-600">
-                                        {keywordRow.keyword}
-                                      </p>
-                                      <p className="text-base text-slate-600">
-                                        {keywordRow.count.toLocaleString("en-US")}명
-                                      </p>
-                                    </Fragment>
-                                  ))}
-                                </div>
-                              </div>
-                            ) : (
-                              <EmptyPanelState
-                                className="mt-4 flex-1"
-                                message="아직 집계된 키워드 데이터가 없습니다."
-                              />
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                      ) : (
-                        <div className="flex min-h-[20rem] items-center justify-center rounded-[1.6rem] bg-[#f7fbf2] text-base font-semibold text-slate-400">
-                          {isDetailLoading ? "이벤트 데이터를 불러오는 중입니다." : "표시할 대시보드 데이터가 없습니다."}
-                        </div>
-                      )
-                    ) : null}
-
-                    {eventDetailTab === "participants" ? (
-                      selectedEventInsights ? (
-                      <div className="space-y-6">
-                        <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-[#fbfcf8]">
-                          <div className="overflow-x-auto">
-                            <Table className="min-w-[940px]">
-                              <TableHeader className="bg-[#f6f8ef]">
-                                <TableRow className="border-none hover:bg-transparent">
-                                  <TableHead className="w-[13rem]">이름</TableHead>
-                                  <TableHead className="w-[16rem]">이메일</TableHead>
-                                  <TableHead className="w-[15rem]">상태</TableHead>
-                                  <TableHead>키워드</TableHead>
-                                </TableRow>
-                              </TableHeader>
-                              <TableBody>
-                                {visibleParticipants.map((participant) => (
-                                  <TableRow key={participant.id}>
-                                    <TableCell className="w-[13rem] min-w-[13rem] whitespace-nowrap text-[1.65rem] font-black tracking-tight text-slate-900">
-                                      {participant.name}
-                                    </TableCell>
-                                    <TableCell className="w-[16rem] min-w-[16rem] whitespace-nowrap text-[1.05rem] text-slate-800">
-                                      {participant.email}
-                                    </TableCell>
-                                    <TableCell className="w-[12rem] min-w-[12rem]">
-                                      <div className="flex items-center gap-3">
-                                        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-200">
-                                          <div
-                                            className="h-full rounded-full bg-brand-500"
-                                            style={{ width: `${participant.progressPercent}%` }}
-                                          />
-                                        </div>
-                                        <span className="text-[1.05rem] font-semibold text-slate-900">
-                                          {participant.progressPercent}%
-                                        </span>
-                                      </div>
-                                    </TableCell>
-                                    <TableCell className="min-w-[24rem]">
-                                      <div className="flex flex-wrap gap-3">
-                                        {participant.keywords.length > 0 ? (
-                                          participant.keywords.map((keyword) => (
-                                            <span
-                                              key={`${participant.id}-${keyword}`}
-                                              className="rounded-xl bg-brand-100 px-4 py-2 text-base font-semibold text-brand-700"
-                                            >
-                                              {keyword}
-                                            </span>
-                                          ))
-                                        ) : (
-                                          <span className="rounded-xl bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500">
-                                            키워드 선택 전
-                                          </span>
-                                        )}
-                                      </div>
-                                    </TableCell>
-                                  </TableRow>
-                                ))}
-                              </TableBody>
-                            </Table>
-                          </div>
-                        </div>
-
-                        <div className="flex items-center justify-center gap-1 text-slate-400">
-                          <button
-                            type="button"
-                            className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
-                            disabled={participantPage === 1}
-                            onClick={() =>
-                              setParticipantPage((previousValue) => Math.max(1, previousValue - 1))
-                            }
-                          >
-                            <ChevronLeftIcon />
-                          </button>
-
-                          {Array.from(
-                            { length: participantTotalPages },
-                            (_, index) => index + 1
-                          ).map((pageNumber) => (
-                            <button
-                              key={pageNumber}
-                              type="button"
-                              className={cn(
-                                "inline-flex h-7 w-7 items-center justify-center rounded-full text-sm hover:bg-brand-50 hover:text-brand-600",
-                                participantPage === pageNumber &&
-                                  "bg-brand-100 font-bold text-brand-700"
-                              )}
-                              onClick={() => setParticipantPage(pageNumber)}
-                            >
-                              {pageNumber}
-                            </button>
-                          ))}
-
-                          <button
-                            type="button"
-                            className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
-                            disabled={participantPage === participantTotalPages}
-                            onClick={() =>
-                              setParticipantPage((previousValue) =>
-                                Math.min(participantTotalPages, previousValue + 1)
-                              )
-                            }
-                          >
-                            <ChevronRightIcon />
-                          </button>
-                        </div>
-                      </div>
-                      ) : (
-                        <div className="flex min-h-[20rem] items-center justify-center rounded-[1.6rem] bg-[#f7fbf2] text-base font-semibold text-slate-400">
-                          {isDetailLoading ? "참가자 목록을 불러오는 중입니다." : "표시할 참가자 데이터가 없습니다."}
-                        </div>
-                      )
-                    ) : null}
-                  </div>
-                ) : (
-                  <div className="flex min-h-[28rem] items-center justify-center">
-                    <div className="space-y-4 text-center">
-                      <p className="text-2xl font-black tracking-tight text-slate-900">
-                        {isDetailLoading ? "이벤트를 불러오는 중입니다." : "선택한 이벤트를 찾을 수 없습니다."}
-                      </p>
-                      {!isDetailLoading ? (
-                        <p className="text-sm text-slate-500">
-                          목록으로 돌아가 다시 선택해 주세요.
-                        </p>
-                      ) : null}
-                      <Button className="rounded-full px-5" onClick={goBackToEventList}>
-                        이벤트 목록으로 이동
-                      </Button>
-                    </div>
-                  </div>
-                )
-              ) : (
-                <>
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                    <h1 className="text-3xl font-black tracking-tight text-brand-800">
-                      이벤트 관리
-                    </h1>
-
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                      <div className="relative w-full sm:w-[19rem]">
-                        <SearchIcon className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                        <Input
-                          value={eventSearchQuery}
-                          onChange={(event) => setEventSearchQuery(event.target.value)}
-                          placeholder="Search"
-                          className="h-10 rounded-2xl border-0 bg-slate-100 pl-11 shadow-none"
-                        />
-                      </div>
-
-                      <Button
-                        className="rounded-full bg-brand-700 px-5 hover:bg-brand-800"
-                        onClick={() => openEventModal()}
-                      >
-                        새 행사 등록
-                        <PlusIcon />
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-[#fbfcf8]">
-                    <div className="overflow-x-auto">
-                      <Table className="min-w-[1020px]">
-                        <TableHeader className="bg-[#f6f8ef]">
-                          <TableRow className="border-none hover:bg-transparent">
-                            <TableHead className="w-[6rem]">번호</TableHead>
-                            <TableHead className="min-w-[18rem]">행사명</TableHead>
-                            <TableHead className="w-[10rem] min-w-[10rem] whitespace-nowrap">
-                              날짜
-                            </TableHead>
-                            <TableHead className="w-[7rem] min-w-[7rem] whitespace-nowrap">
-                              참여자수
-                            </TableHead>
-                            <TableHead>상태</TableHead>
-                            <TableHead>진행도</TableHead>
-                            <TableHead className="w-[4rem]" />
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {visibleEvents.map((eventItem, index) => (
-                            <TableRow
-                              key={eventItem.id}
-                              className="cursor-pointer"
-                              onClick={() => goToEventDetail(eventItem.id)}
-                            >
-                              <TableCell className="font-bold text-slate-900">
-                                {(eventPage - 1) * ITEMS_PER_PAGE + index + 1}
-                              </TableCell>
-                              <TableCell className="min-w-[18rem] font-semibold text-slate-800">
-                                <div className="space-y-2">
-                                  <p>{eventItem.name}</p>
-                                  <div className="flex flex-wrap items-center gap-2 text-xs">
-                                    <span className="rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-500">
-                                      {getEventHomePath(eventItem.slug)}
-                                    </span>
-                                    <span
-                                      className={cn(
-                                        "rounded-full px-2.5 py-1 font-semibold",
-                                        eventItem.canEdit
-                                          ? "bg-brand-100 text-brand-700"
-                                          : "bg-slate-100 text-slate-500"
-                                      )}
-                                    >
-                                      {eventItem.canEdit ? "내 행사" : "읽기 전용"}
+                              <div className="flex min-w-0 flex-1 flex-col justify-between gap-6">
+                                <div className="space-y-3">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <EventStatusBadge
+                                      status={selectedEvent.status}
+                                    />
+                                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-500">
+                                      {selectedEventTimeRange}
                                     </span>
                                   </div>
+                                  <div>
+                                    <p className="text-xs font-black uppercase tracking-[0.18em] text-slate-300">
+                                      Event Overview
+                                    </p>
+                                    <h2 className="mt-2 text-[2rem] font-black leading-tight tracking-tight text-slate-900 sm:text-[2.35rem]">
+                                      {selectedEvent.name}
+                                    </h2>
+                                  </div>
                                 </div>
-                              </TableCell>
-                              <TableCell className="whitespace-nowrap">
-                                <span className="inline-flex rounded-lg bg-slate-100 px-3 py-2 font-medium text-slate-700">
-                                  {formatEventRowDate(eventItem.startAt)}
+
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                  <div className="rounded-2xl bg-[#f7fbf2] px-4 py-3">
+                                    <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
+                                      운영팀
+                                    </p>
+                                    <p className="mt-2 text-sm font-bold text-brand-700">
+                                      {selectedEvent.eventTeam}
+                                    </p>
+                                  </div>
+                                  <div className="rounded-2xl bg-[#f7fbf2] px-4 py-3">
+                                    <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
+                                      장소
+                                    </p>
+                                    <p className="mt-2 text-sm font-bold text-slate-700">
+                                      {selectedEvent.location}
+                                    </p>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                          <div className="space-y-4">
+                            <div className="rounded-[1.5rem] bg-[#f7fbf2] p-5 ring-1 ring-white/70">
+                              <p className="text-sm font-black text-slate-900">
+                                빙고 설정
+                              </p>
+                              <div className="mt-4 grid grid-cols-3 gap-2">
+                                <div className="rounded-2xl bg-white px-3 py-3 text-center ring-1 ring-slate-100">
+                                  <p className="text-xs font-bold text-slate-400">
+                                    보드
+                                  </p>
+                                  <p className="mt-1 text-lg font-black text-brand-700">
+                                    {selectedEvent.boardSize}x
+                                    {selectedEvent.boardSize}
+                                  </p>
+                                </div>
+                                <div className="rounded-2xl bg-white px-3 py-3 text-center ring-1 ring-slate-100">
+                                  <p className="text-xs font-bold text-slate-400">
+                                    미션
+                                  </p>
+                                  <p className="mt-1 text-lg font-black text-brand-700">
+                                    {selectedEvent.bingoMissionCount}
+                                  </p>
+                                </div>
+                                <div className="rounded-2xl bg-white px-3 py-3 text-center ring-1 ring-slate-100">
+                                  <p className="text-xs font-bold text-slate-400">
+                                    키워드
+                                  </p>
+                                  <p className="mt-1 text-lg font-black text-brand-700">
+                                    {selectedEvent.keywords.length}
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+
+                            <div className="rounded-[1.5rem] bg-white p-5 shadow-[0_14px_36px_rgba(15,23,42,0.05)] ring-1 ring-slate-100">
+                              <div className="mb-4 flex items-center justify-between gap-3">
+                                <p className="text-sm font-black text-slate-900">
+                                  키워드
+                                </p>
+                                <span className="whitespace-nowrap rounded-full bg-brand-50 px-3 py-1 text-xs font-black text-brand-700">
+                                  {selectedEvent.keywords.length}개
                                 </span>
-                              </TableCell>
-                              <TableCell className="whitespace-nowrap text-lg font-medium text-slate-800">
-                                {eventItem.participantCount}
-                              </TableCell>
-                              <TableCell>
-                                <EventStatusBadge status={eventItem.status} />
-                              </TableCell>
-                              <TableCell className="min-w-[20rem]">
-                                <EventProgress
-                                  current={eventItem.progressCurrent}
-                                  total={eventItem.progressTotal}
-                                />
-                              </TableCell>
-                              <TableCell>
-                                <button
-                                  type="button"
-                                  className="inline-flex h-9 w-9 items-center justify-center rounded-full text-brand-500 hover:bg-brand-50"
-                                  aria-label={`${eventItem.name} 상세 보기`}
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    goToEventDetail(eventItem.id);
-                                  }}
+                              </div>
+                              <div className="flex max-h-[12rem] flex-wrap gap-2 overflow-y-auto pr-1 [scrollbar-gutter:stable_both-edges]">
+                                {selectedEvent.keywords.map((keyword) => (
+                                  <span
+                                    key={keyword}
+                                    className="rounded-xl bg-brand-100 px-3 py-1.5 text-sm font-semibold text-brand-700"
+                                  >
+                                    {keyword}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+
+                      {eventDetailTab === "share" ? (
+                        <EventQrShareCard
+                          eventName={selectedEvent.name}
+                          shareUrl={selectedEventShareUrl}
+                        />
+                      ) : null}
+
+                      {eventDetailTab === "dashboard" ? (
+                        selectedEventInsights ? (
+                          <div className="space-y-7">
+                            <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+                              {[
+                                {
+                                  label: "참여자 수",
+                                  value:
+                                    selectedEvent.participantCount.toLocaleString(
+                                      "en-US",
+                                    ),
+                                  unit: "명",
+                                  priority: "primary",
+                                },
+                                {
+                                  label: "총 키워드 교환 횟수",
+                                  value:
+                                    selectedEventInsights.totalKeywordSelections.toLocaleString(
+                                      "en-US",
+                                    ),
+                                  unit: "회",
+                                  priority: "primary",
+                                },
+                                {
+                                  label: "리뷰 참여자",
+                                  value:
+                                    selectedEventInsights.reviewParticipants.toLocaleString(
+                                      "en-US",
+                                    ),
+                                  unit: "명",
+                                  priority: "secondary",
+                                },
+                                {
+                                  label: "리뷰 평균 점수",
+                                  value:
+                                    selectedEventInsights.averageReviewScore.toFixed(
+                                      1,
+                                    ),
+                                  unit: "/5",
+                                  priority: "secondary",
+                                },
+                                {
+                                  label: "리뷰 참여율",
+                                  value:
+                                    selectedEventInsights.participationRate.toFixed(
+                                      1,
+                                    ),
+                                  unit: "%",
+                                  priority: "primary",
+                                },
+                                {
+                                  label: "운영 시간",
+                                  value: formatDurationLabel(
+                                    selectedEventInsights.operatingMinutes,
+                                  ),
+                                  priority: "secondary",
+                                },
+                              ].map((metricItem) => (
+                                <div
+                                  key={metricItem.label}
+                                  className={cn(
+                                    "rounded-[1.5rem] px-6 transition-shadow xl:col-span-2",
+                                    metricItem.priority === "primary"
+                                      ? "bg-white py-7 shadow-[0_18px_48px_rgba(15,23,42,0.08)] ring-1 ring-brand-100"
+                                      : "bg-[#f7fbf2] py-5 ring-1 ring-white/70",
+                                  )}
                                 >
-                                  <ChevronRightIcon />
+                                  <p
+                                    className={cn(
+                                      "font-black",
+                                      metricItem.priority === "primary"
+                                        ? "text-sm text-brand-700"
+                                        : "text-xs uppercase tracking-[0.14em] text-slate-400",
+                                    )}
+                                  >
+                                    {metricItem.label}
+                                  </p>
+                                  <div
+                                    className={cn(
+                                      "flex items-end gap-2",
+                                      metricItem.priority === "primary"
+                                        ? "mt-8"
+                                        : "mt-5",
+                                    )}
+                                  >
+                                    <span
+                                      className={cn(
+                                        "font-black tracking-tight text-slate-900",
+                                        metricItem.priority === "primary"
+                                          ? "text-[2.35rem]"
+                                          : "text-[1.7rem]",
+                                      )}
+                                    >
+                                      {metricItem.value}
+                                    </span>
+                                    {metricItem.unit ? (
+                                      <span
+                                        className={cn(
+                                          "pb-1 font-black",
+                                          metricItem.priority === "primary"
+                                            ? "text-xl text-brand-700"
+                                            : "text-sm text-slate-400",
+                                        )}
+                                      >
+                                        {metricItem.unit}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+
+                            <div className="grid gap-5 xl:grid-cols-2">
+                              <div className="flex h-[24rem] flex-col rounded-[1.6rem] bg-white p-5 shadow-[0_14px_36px_rgba(15,23,42,0.06)] ring-1 ring-slate-100">
+                                <div className="flex items-start justify-between gap-4">
+                                  <div>
+                                    <p className="text-base font-black text-slate-900">
+                                      빙고 정보
+                                    </p>
+                                    <p className="mt-1 text-xs font-semibold text-slate-400">
+                                      달성 줄 수별 완료 분포
+                                    </p>
+                                  </div>
+                                  <span className="rounded-full bg-brand-50 px-3 py-1 text-xs font-black text-brand-700">
+                                    Board
+                                  </span>
+                                </div>
+                                <div className="mt-6 grid grid-cols-[1.2fr_0.8fr_0.7fr] gap-x-4 rounded-2xl bg-[#f7fbf2] px-3 py-2">
+                                  <SortHeaderButton
+                                    active={bingoSort.key === "line"}
+                                    direction={bingoSort.direction}
+                                    onClick={() => toggleBingoSort("line")}
+                                    className="text-sm"
+                                  >
+                                    달성 줄 수
+                                  </SortHeaderButton>
+                                  <SortHeaderButton
+                                    active={bingoSort.key === "count"}
+                                    direction={bingoSort.direction}
+                                    onClick={() => toggleBingoSort("count")}
+                                    className="text-sm"
+                                  >
+                                    인원 수
+                                  </SortHeaderButton>
+                                  <SortHeaderButton
+                                    active={bingoSort.key === "rate"}
+                                    direction={bingoSort.direction}
+                                    onClick={() => toggleBingoSort("rate")}
+                                    className="text-sm"
+                                  >
+                                    비율
+                                  </SortHeaderButton>
+                                </div>
+                                {sortedBingoRows.length > 0 ? (
+                                  <div className="-mr-2 mt-3 flex-1 overflow-y-auto pr-4 [scrollbar-gutter:stable_both-edges]">
+                                    <div className="space-y-1.5 pb-1">
+                                      {sortedBingoRows.map((bingoRow) => (
+                                        <div
+                                          key={bingoRow.lineLabel}
+                                          className="grid grid-cols-[1.2fr_0.8fr_0.7fr] items-center gap-x-4 rounded-2xl px-3 py-2.5 text-sm text-slate-600 hover:bg-[#f7fbf2]"
+                                        >
+                                          <div className="flex items-center gap-2 leading-6">
+                                            <span>{bingoRow.lineLabel}</span>
+                                            {bingoRow.isComplete ? (
+                                              <span className="rounded-full bg-brand-300 px-2.5 py-1 text-[0.7rem] font-bold text-white">
+                                                빙고 완성
+                                              </span>
+                                            ) : null}
+                                          </div>
+                                          <p>
+                                            {bingoRow.count.toLocaleString(
+                                              "en-US",
+                                            )}
+                                            명
+                                          </p>
+                                          <p>{bingoRow.rate}%</p>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <EmptyPanelState
+                                    className="mt-4 flex-1"
+                                    message="아직 집계된 빙고 데이터가 없습니다."
+                                  />
+                                )}
+                              </div>
+
+                              <div className="flex h-[24rem] flex-col rounded-[1.6rem] bg-white p-5 shadow-[0_14px_36px_rgba(15,23,42,0.06)] ring-1 ring-slate-100">
+                                <div className="flex items-start justify-between gap-4">
+                                  <div>
+                                    <p className="text-base font-black text-slate-900">
+                                      키워드 별 선택 횟수
+                                    </p>
+                                    <p className="mt-1 text-xs font-semibold text-slate-400">
+                                      참가자가 많이 선택한 키워드
+                                    </p>
+                                  </div>
+                                  <span className="rounded-full bg-brand-50 px-3 py-1 text-xs font-black text-brand-700">
+                                    Keywords
+                                  </span>
+                                </div>
+                                <div className="mt-6 grid grid-cols-[0.6fr_1.5fr_1fr] gap-x-4 rounded-2xl bg-[#f7fbf2] px-3 py-2">
+                                  <SortHeaderButton
+                                    active={keywordSort.key === "rank"}
+                                    direction={keywordSort.direction}
+                                    onClick={() => toggleKeywordSort("rank")}
+                                    className="text-sm"
+                                  >
+                                    순위
+                                  </SortHeaderButton>
+                                  <SortHeaderButton
+                                    active={keywordSort.key === "keyword"}
+                                    direction={keywordSort.direction}
+                                    onClick={() => toggleKeywordSort("keyword")}
+                                    className="text-sm"
+                                  >
+                                    키워드
+                                  </SortHeaderButton>
+                                  <SortHeaderButton
+                                    active={keywordSort.key === "count"}
+                                    direction={keywordSort.direction}
+                                    onClick={() => toggleKeywordSort("count")}
+                                    className="text-sm"
+                                  >
+                                    선택한 사람 수
+                                  </SortHeaderButton>
+                                </div>
+                                {sortedKeywordRows.length > 0 ? (
+                                  <div className="-mr-2 mt-3 flex-1 overflow-y-auto pr-4 [scrollbar-gutter:stable_both-edges]">
+                                    <div className="space-y-1.5 pb-1">
+                                      {sortedKeywordRows.map((keywordRow) => (
+                                        <div
+                                          key={keywordRow.keyword}
+                                          className="grid grid-cols-[0.6fr_1.5fr_1fr] items-center gap-x-4 rounded-2xl px-3 py-2.5 text-sm text-slate-600 hover:bg-[#f7fbf2]"
+                                        >
+                                          <p>{keywordRow.rank}</p>
+                                          <p className="break-words leading-6">
+                                            {keywordRow.keyword}
+                                          </p>
+                                          <p>
+                                            {keywordRow.count.toLocaleString(
+                                              "en-US",
+                                            )}
+                                            명
+                                          </p>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <EmptyPanelState
+                                    className="mt-4 flex-1"
+                                    message="아직 집계된 키워드 데이터가 없습니다."
+                                  />
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex min-h-[20rem] items-center justify-center rounded-[1.6rem] bg-[#f7fbf2] text-base font-semibold text-slate-400">
+                            {isDetailLoading
+                              ? "이벤트 데이터를 불러오는 중입니다."
+                              : "표시할 대시보드 데이터가 없습니다."}
+                          </div>
+                        )
+                      ) : null}
+
+                      {eventDetailTab === "participants" ? (
+                        selectedEventInsights ? (
+                          <div className="space-y-5">
+                            <div className="flex flex-col gap-2 rounded-[1.25rem] bg-white px-5 py-4 shadow-[0_12px_30px_rgba(15,23,42,0.05)] ring-1 ring-slate-100 sm:flex-row sm:items-center sm:justify-between">
+                              <div>
+                                <p className="text-base font-black text-slate-900">
+                                  참가자 목록
+                                </p>
+                                <p className="mt-1 text-xs font-semibold leading-5 text-slate-400">
+                                  이름, 이메일, 진행률, 선택 키워드 수로 정렬해
+                                  현장 대응 대상을 빠르게 찾을 수 있습니다.
+                                </p>
+                              </div>
+                              <span className="whitespace-nowrap rounded-full bg-brand-50 px-4 py-2 text-sm font-black text-brand-700">
+                                총{" "}
+                                {sortedParticipants.length.toLocaleString(
+                                  "en-US",
+                                )}
+                                명
+                              </span>
+                            </div>
+                            <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-white shadow-[0_14px_36px_rgba(15,23,42,0.05)]">
+                              <div className="overflow-x-auto">
+                                <Table className="min-w-[940px]">
+                                  <TableHeader className="bg-[#f7fbf2]">
+                                    <TableRow className="border-none hover:bg-transparent">
+                                      <TableHead className="w-[13rem]">
+                                        <SortHeaderButton
+                                          active={
+                                            participantSort.key === "name"
+                                          }
+                                          direction={participantSort.direction}
+                                          onClick={() =>
+                                            toggleParticipantSort("name")
+                                          }
+                                        >
+                                          이름
+                                        </SortHeaderButton>
+                                      </TableHead>
+                                      <TableHead className="w-[16rem]">
+                                        <SortHeaderButton
+                                          active={
+                                            participantSort.key === "email"
+                                          }
+                                          direction={participantSort.direction}
+                                          onClick={() =>
+                                            toggleParticipantSort("email")
+                                          }
+                                        >
+                                          이메일
+                                        </SortHeaderButton>
+                                      </TableHead>
+                                      <TableHead className="w-[15rem]">
+                                        <SortHeaderButton
+                                          active={
+                                            participantSort.key === "progress"
+                                          }
+                                          direction={participantSort.direction}
+                                          onClick={() =>
+                                            toggleParticipantSort("progress")
+                                          }
+                                        >
+                                          진행률
+                                        </SortHeaderButton>
+                                      </TableHead>
+                                      <TableHead>
+                                        <SortHeaderButton
+                                          active={
+                                            participantSort.key === "keywords"
+                                          }
+                                          direction={participantSort.direction}
+                                          onClick={() =>
+                                            toggleParticipantSort("keywords")
+                                          }
+                                        >
+                                          키워드 수
+                                        </SortHeaderButton>
+                                      </TableHead>
+                                    </TableRow>
+                                  </TableHeader>
+                                  <TableBody>
+                                    {visibleParticipants.map((participant) => (
+                                      <TableRow
+                                        key={participant.id}
+                                        className="hover:bg-[#fbfcf8]"
+                                      >
+                                        <TableCell className="w-[13rem] min-w-[13rem] whitespace-nowrap text-base font-bold tracking-tight text-slate-900">
+                                          {participant.name}
+                                        </TableCell>
+                                        <TableCell className="w-[16rem] min-w-[16rem] whitespace-nowrap text-sm text-slate-700">
+                                          {participant.email}
+                                        </TableCell>
+                                        <TableCell className="w-[12rem] min-w-[12rem]">
+                                          <div className="flex items-center gap-3">
+                                            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-200">
+                                              <div
+                                                className="h-full rounded-full bg-brand-500"
+                                                style={{
+                                                  width: `${participant.progressPercent}%`,
+                                                }}
+                                              />
+                                            </div>
+                                            <span className="text-sm font-semibold text-slate-900">
+                                              {participant.progressPercent}%
+                                            </span>
+                                          </div>
+                                        </TableCell>
+                                        <TableCell className="min-w-[24rem]">
+                                          <div className="flex flex-wrap gap-3">
+                                            <span className="whitespace-nowrap rounded-xl bg-white px-3 py-1.5 text-sm font-bold text-slate-700 ring-1 ring-slate-100">
+                                              {participant.keywords.length}개
+                                            </span>
+                                            {participant.keywords.length > 0 ? (
+                                              participant.keywords.map(
+                                                (keyword) => (
+                                                  <span
+                                                    key={`${participant.id}-${keyword}`}
+                                                    className="rounded-xl bg-brand-100 px-3 py-1.5 text-sm font-semibold text-brand-700"
+                                                  >
+                                                    {keyword}
+                                                  </span>
+                                                ),
+                                              )
+                                            ) : (
+                                              <span className="rounded-xl bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500">
+                                                키워드 선택 전
+                                              </span>
+                                            )}
+                                          </div>
+                                        </TableCell>
+                                      </TableRow>
+                                    ))}
+                                  </TableBody>
+                                </Table>
+                              </div>
+                            </div>
+
+                            <div className="flex items-center justify-center gap-1 text-slate-400">
+                              <button
+                                type="button"
+                                className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
+                                disabled={participantPage === 1}
+                                onClick={() =>
+                                  setParticipantPage((previousValue) =>
+                                    Math.max(1, previousValue - 1),
+                                  )
+                                }
+                              >
+                                <ChevronLeftIcon />
+                              </button>
+
+                              {Array.from(
+                                { length: participantTotalPages },
+                                (_, index) => index + 1,
+                              ).map((pageNumber) => (
+                                <button
+                                  key={pageNumber}
+                                  type="button"
+                                  className={cn(
+                                    "inline-flex h-7 w-7 items-center justify-center rounded-full text-sm hover:bg-brand-50 hover:text-brand-600",
+                                    participantPage === pageNumber &&
+                                      "bg-brand-100 font-bold text-brand-700",
+                                  )}
+                                  onClick={() => setParticipantPage(pageNumber)}
+                                >
+                                  {pageNumber}
                                 </button>
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
+                              ))}
+
+                              <button
+                                type="button"
+                                className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
+                                disabled={
+                                  participantPage === participantTotalPages
+                                }
+                                onClick={() =>
+                                  setParticipantPage((previousValue) =>
+                                    Math.min(
+                                      participantTotalPages,
+                                      previousValue + 1,
+                                    ),
+                                  )
+                                }
+                              >
+                                <ChevronRightIcon />
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex min-h-[20rem] items-center justify-center rounded-[1.6rem] bg-[#f7fbf2] text-base font-semibold text-slate-400">
+                            {isDetailLoading
+                              ? "참가자 목록을 불러오는 중입니다."
+                              : "표시할 참가자 데이터가 없습니다."}
+                          </div>
+                        )
+                      ) : null}
                     </div>
-                  </div>
+                  ) : (
+                    <div className="flex min-h-[28rem] items-center justify-center">
+                      <div className="space-y-4 text-center">
+                        <p className="text-2xl font-black tracking-tight text-slate-900">
+                          {isDetailLoading
+                            ? "이벤트를 불러오는 중입니다."
+                            : "선택한 이벤트를 찾을 수 없습니다."}
+                        </p>
+                        {!isDetailLoading ? (
+                          <p className="text-sm text-slate-500">
+                            목록으로 돌아가 다시 선택해 주세요.
+                          </p>
+                        ) : null}
+                        <Button
+                          className="rounded-full px-5"
+                          onClick={goBackToEventList}
+                        >
+                          이벤트 목록으로 이동
+                        </Button>
+                      </div>
+                    </div>
+                  )
+                ) : (
+                  <>
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                      <h1 className="text-3xl font-black tracking-tight text-brand-800">
+                        이벤트 관리
+                      </h1>
 
-                  <div className="flex items-center justify-center gap-1 text-slate-400">
-                    <button
-                      type="button"
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
-                      disabled={eventPage === 1}
-                      onClick={() =>
-                        setEventPage((previousValue) => Math.max(1, previousValue - 1))
-                      }
-                    >
-                      <ChevronLeftIcon />
-                    </button>
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                        <div className="relative w-full sm:w-[19rem]">
+                          <SearchIcon className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                          <Input
+                            value={eventSearchQuery}
+                            onChange={(event) =>
+                              setEventSearchQuery(event.target.value)
+                            }
+                            placeholder="Search"
+                            className="h-10 rounded-2xl border-0 bg-slate-100 pl-11 shadow-none"
+                          />
+                        </div>
 
-                    {Array.from({ length: eventTotalPages }, (_, index) => index + 1).map(
-                      (pageNumber) => (
+                        <Button
+                          className="rounded-full bg-brand-700 px-5 hover:bg-brand-800"
+                          onClick={() => openEventModal()}
+                        >
+                          새 행사 등록
+                          <PlusIcon />
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-[#fbfcf8]">
+                      <div className="overflow-x-auto">
+                        <Table className="min-w-[1020px]">
+                          <TableHeader className="bg-[#f6f8ef]">
+                            <TableRow className="border-none hover:bg-transparent">
+                              <TableHead className="w-[6rem]">번호</TableHead>
+                              <TableHead className="min-w-[18rem]">
+                                행사명
+                              </TableHead>
+                              <TableHead className="w-[10rem] min-w-[10rem] whitespace-nowrap">
+                                날짜
+                              </TableHead>
+                              <TableHead className="w-[7rem] min-w-[7rem] whitespace-nowrap">
+                                참여자수
+                              </TableHead>
+                              <TableHead>상태</TableHead>
+                              <TableHead>진행도</TableHead>
+                              <TableHead className="w-[4rem]" />
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {visibleEvents.map((eventItem, index) => (
+                              <TableRow
+                                key={eventItem.id}
+                                className="cursor-pointer"
+                                onClick={() => goToEventDetail(eventItem.id)}
+                              >
+                                <TableCell className="font-bold text-slate-900">
+                                  {(eventPage - 1) * ITEMS_PER_PAGE + index + 1}
+                                </TableCell>
+                                <TableCell className="min-w-[18rem] font-semibold text-slate-800">
+                                  <div className="space-y-2">
+                                    <p>{eventItem.name}</p>
+                                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                                      <span className="rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-500">
+                                        {getEventHomePath(eventItem.slug)}
+                                      </span>
+                                      <span
+                                        className={cn(
+                                          "rounded-full px-2.5 py-1 font-semibold",
+                                          eventItem.canEdit
+                                            ? "bg-brand-100 text-brand-700"
+                                            : "bg-slate-100 text-slate-500",
+                                        )}
+                                      >
+                                        {eventItem.canEdit
+                                          ? "내 행사"
+                                          : "읽기 전용"}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="whitespace-nowrap">
+                                  <span className="inline-flex rounded-lg bg-slate-100 px-3 py-2 font-medium text-slate-700">
+                                    {formatEventRowDate(eventItem.startAt)}
+                                  </span>
+                                </TableCell>
+                                <TableCell className="whitespace-nowrap text-lg font-medium text-slate-800">
+                                  {eventItem.participantCount}
+                                </TableCell>
+                                <TableCell>
+                                  <EventStatusBadge status={eventItem.status} />
+                                </TableCell>
+                                <TableCell className="min-w-[20rem]">
+                                  <EventProgress
+                                    current={eventItem.progressCurrent}
+                                    total={eventItem.progressTotal}
+                                  />
+                                </TableCell>
+                                <TableCell>
+                                  <button
+                                    type="button"
+                                    className="inline-flex h-9 w-9 items-center justify-center rounded-full text-brand-500 hover:bg-brand-50"
+                                    aria-label={`${eventItem.name} 상세 보기`}
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      goToEventDetail(eventItem.id);
+                                    }}
+                                  >
+                                    <ChevronRightIcon />
+                                  </button>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center justify-center gap-1 text-slate-400">
+                      <button
+                        type="button"
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
+                        disabled={eventPage === 1}
+                        onClick={() =>
+                          setEventPage((previousValue) =>
+                            Math.max(1, previousValue - 1),
+                          )
+                        }
+                      >
+                        <ChevronLeftIcon />
+                      </button>
+
+                      {Array.from(
+                        { length: eventTotalPages },
+                        (_, index) => index + 1,
+                      ).map((pageNumber) => (
                         <button
                           key={pageNumber}
                           type="button"
                           className={cn(
                             "inline-flex h-7 w-7 items-center justify-center rounded-full text-sm hover:bg-brand-50 hover:text-brand-600",
-                            eventPage === pageNumber && "bg-brand-100 font-bold text-brand-700"
+                            eventPage === pageNumber &&
+                              "bg-brand-100 font-bold text-brand-700",
                           )}
                           onClick={() => setEventPage(pageNumber)}
                         >
                           {pageNumber}
                         </button>
-                      )
-                    )}
+                      ))}
 
-                    <button
-                      type="button"
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
-                      disabled={eventPage === eventTotalPages}
-                      onClick={() =>
-                        setEventPage((previousValue) =>
-                          Math.min(eventTotalPages, previousValue + 1)
-                        )
-                      }
-                    >
-                      <ChevronRightIcon />
-                    </button>
-                  </div>
-                </>
-              )
-            ) : null}
-
-            {section === "policies" ? (
-              <>
-                <SectionHeader
-                  title="개인정보 처리 안내"
-                  description="행사 참가자 안내 템플릿을 관리합니다. 플랫폼 개인정보처리방침은 프론트 고정 문서로 관리합니다."
-                  action={
-                    canEditPolicyTemplate ? (
-                      <div className="flex flex-wrap items-center gap-3">
-                        <Button
-                          variant="outline"
-                          className="rounded-full px-5"
-                          disabled={!hasPolicyChanges || isPolicySaving}
-                          onClick={handleResetPolicyDraft}
-                        >
-                          되돌리기
-                        </Button>
-                        <Button
-                          className="rounded-full px-5"
-                          disabled={!hasPolicyChanges || isPolicySaving}
-                          onClick={() => void handleSavePolicyTemplate()}
-                        >
-                          {isPolicySaving ? "저장 중" : "템플릿 저장"}
-                        </Button>
-                      </div>
-                    ) : (
-                      <span className="self-start rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500 md:self-auto">
-                        조회 전용
-                      </span>
-                    )
-                  }
-                />
-
-                {policyError ? (
-                  <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
-                    {policyError}
-                  </div>
-                ) : null}
-                {policyNotice ? (
-                  <div className="rounded-2xl border border-brand-100 bg-brand-50 px-4 py-3 text-sm font-semibold text-brand-800">
-                    {policyNotice}
-                  </div>
-                ) : null}
-
-                <div className="flex flex-wrap gap-3">
-                  {POLICY_TEMPLATE_OPTIONS.map((option) => {
-                    const isSelected = option.key === selectedPolicyKey;
-                    return (
                       <button
-                        key={option.key}
                         type="button"
-                        className={cn(
-                          "rounded-full border px-4 py-2 text-sm font-semibold transition-colors",
-                          isSelected
-                            ? "border-brand-600 bg-brand-600 text-white"
-                            : "border-slate-200 bg-white text-slate-600 hover:border-brand-200 hover:text-brand-700"
-                        )}
-                        onClick={() => {
-                          setSelectedPolicyKey(option.key);
-                          setPolicyError("");
-                          setPolicyNotice("");
-                        }}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-brand-50 hover:text-brand-600 disabled:opacity-30"
+                        disabled={eventPage === eventTotalPages}
+                        onClick={() =>
+                          setEventPage((previousValue) =>
+                            Math.min(eventTotalPages, previousValue + 1),
+                          )
+                        }
                       >
-                        {option.label}
+                        <ChevronRightIcon />
                       </button>
-                    );
-                  })}
-                </div>
+                    </div>
+                  </>
+                )
+              ) : null}
 
-                <div className="grid gap-4 xl:grid-cols-[18rem_minmax(0,1fr)] xl:min-h-[calc(100vh-16rem)]">
-                  <Card className="overflow-hidden rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
-                    <CardHeader className="space-y-2 p-7 pb-0">
-                      <CardTitle>템플릿 안내</CardTitle>
-                      <CardDescription>
-                        저장 즉시 로그인 전 안내 모달과 행사별 개인정보 안내 페이지에
-                        반영됩니다. 플랫폼 개인정보처리방침은 프론트 고정 문서로 관리합니다.
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-3 p-7 pt-6">
-                      <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                          현재 선택
-                        </p>
-                        <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
-                          {selectedPolicyOption.label}
-                        </p>
-                        <p className="mt-1 text-sm leading-6 text-slate-500">
-                          {selectedPolicyOption.description}
-                        </p>
-                      </div>
-                      <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                          수정 권한
-                        </p>
-                        <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
-                          Admin만 수정할 수 있고, Event Manager는 같은 문안을 읽기 전용으로 확인합니다.
-                        </p>
-                      </div>
-                      <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                          치환 변수
-                        </p>
-                        <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
-                          행사 참가자 안내는{" "}
-                          {"{eventName}, {eventTeam}, {eventContactEmail}, {platformHost}"}를
-                          사용합니다.
-                        </p>
-                      </div>
-                      <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                          마지막 수정
-                        </p>
-                        <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
-                          {activePolicyTemplate
-                            ? `${activePolicyTemplate.updatedByName ?? "시스템 기본값"} · ${formatAdminDate(
-                                activePolicyTemplate.updatedAt
-                              )}`
-                            : "아직 불러오지 않았습니다."}
-                        </p>
-                      </div>
-                      <div className="rounded-[1.35rem] border border-amber-100 bg-amber-50/80 px-4 py-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-700">
-                          게시 전 점검
-                        </p>
-                        <p className="mt-2 text-sm font-semibold leading-6 text-amber-900">
-                          기본값은 개인식별정보 1년 이내 삭제·익명화와 익명 통계·행사 아카이브
-                          장기 보관 기준입니다. Google/Supabase의 위탁, 제3자 제공, 국외 이전
-                          해당 여부는 실제 연동 방식과 계약관계, 데이터 저장 위치 확인 후 확정해 주세요.
-                        </p>
-                      </div>
-                    </CardContent>
-                  </Card>
+              {section === "policies" ? (
+                <>
+                  <SectionHeader
+                    title="개인정보 처리 안내"
+                    description="행사 참가자 안내 템플릿을 관리합니다. 플랫폼 개인정보처리방침은 프론트 고정 문서로 관리합니다."
+                    action={
+                      canEditPolicyTemplate ? (
+                        <div className="flex flex-wrap items-center gap-3">
+                          <Button
+                            variant="outline"
+                            className="rounded-full px-5"
+                            disabled={!hasPolicyChanges || isPolicySaving}
+                            onClick={handleResetPolicyDraft}
+                          >
+                            되돌리기
+                          </Button>
+                          <Button
+                            className="rounded-full px-5"
+                            disabled={!hasPolicyChanges || isPolicySaving}
+                            onClick={() => void handleSavePolicyTemplate()}
+                          >
+                            {isPolicySaving ? "저장 중" : "템플릿 저장"}
+                          </Button>
+                        </div>
+                      ) : (
+                        <span className="self-start rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-500 md:self-auto">
+                          조회 전용
+                        </span>
+                      )
+                    }
+                  />
 
-                  <div className="grid min-h-0 gap-4">
-                    {canEditPolicyTemplate ? (
-                      <Card className="overflow-hidden rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
+                  {policyError ? (
+                    <div className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+                      {policyError}
+                    </div>
+                  ) : null}
+                  {policyNotice ? (
+                    <div className="rounded-2xl border border-brand-100 bg-brand-50 px-4 py-3 text-sm font-semibold text-brand-800">
+                      {policyNotice}
+                    </div>
+                  ) : null}
+
+                  <div className="flex flex-wrap gap-3">
+                    {POLICY_TEMPLATE_OPTIONS.map((option) => {
+                      const isSelected = option.key === selectedPolicyKey;
+                      return (
+                        <button
+                          key={option.key}
+                          type="button"
+                          className={cn(
+                            "rounded-full border px-4 py-2 text-sm font-semibold transition-colors",
+                            isSelected
+                              ? "border-brand-600 bg-brand-600 text-white"
+                              : "border-slate-200 bg-white text-slate-600 hover:border-brand-200 hover:text-brand-700",
+                          )}
+                          onClick={() => {
+                            setSelectedPolicyKey(option.key);
+                            setPolicyError("");
+                            setPolicyNotice("");
+                          }}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div className="grid gap-4 xl:grid-cols-[18rem_minmax(0,1fr)] xl:min-h-[calc(100vh-16rem)]">
+                    <Card className="overflow-hidden rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
+                      <CardHeader className="space-y-2 p-7 pb-0">
+                        <CardTitle>템플릿 안내</CardTitle>
+                        <CardDescription>
+                          저장 즉시 로그인 전 안내 모달과 행사별 개인정보 안내
+                          페이지에 반영됩니다. 플랫폼 개인정보처리방침은 프론트
+                          고정 문서로 관리합니다.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="space-y-3 p-7 pt-6">
+                        <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
+                          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                            현재 선택
+                          </p>
+                          <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
+                            {selectedPolicyOption.label}
+                          </p>
+                          <p className="mt-1 text-sm leading-6 text-slate-500">
+                            {selectedPolicyOption.description}
+                          </p>
+                        </div>
+                        <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
+                          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                            수정 권한
+                          </p>
+                          <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
+                            Admin만 수정할 수 있고, Event Manager는 같은 문안을
+                            읽기 전용으로 확인합니다.
+                          </p>
+                        </div>
+                        <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
+                          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                            치환 변수
+                          </p>
+                          <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
+                            행사 참가자 안내는{" "}
+                            {
+                              "{eventName}, {eventTeam}, {eventContactEmail}, {platformHost}"
+                            }
+                            를 사용합니다.
+                          </p>
+                        </div>
+                        <div className="rounded-[1.35rem] border border-white/90 bg-white/90 px-4 py-4">
+                          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                            마지막 수정
+                          </p>
+                          <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
+                            {activePolicyTemplate
+                              ? `${activePolicyTemplate.updatedByName ?? "시스템 기본값"} · ${formatAdminDate(
+                                  activePolicyTemplate.updatedAt,
+                                )}`
+                              : "아직 불러오지 않았습니다."}
+                          </p>
+                        </div>
+                        <div className="rounded-[1.35rem] border border-amber-100 bg-amber-50/80 px-4 py-4">
+                          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-700">
+                            게시 전 점검
+                          </p>
+                          <p className="mt-2 text-sm font-semibold leading-6 text-amber-900">
+                            기본값은 개인식별정보 1년 이내 삭제·익명화와 익명
+                            통계·행사 아카이브 장기 보관 기준입니다.
+                            Google/Supabase의 위탁, 제3자 제공, 국외 이전 해당
+                            여부는 실제 연동 방식과 계약관계, 데이터 저장 위치
+                            확인 후 확정해 주세요.
+                          </p>
+                        </div>
+                      </CardContent>
+                    </Card>
+
+                    <div className="grid min-h-0 gap-4">
+                      {canEditPolicyTemplate ? (
+                        <Card className="overflow-hidden rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
+                          <CardHeader className="space-y-2 p-7 pb-0">
+                            <CardTitle>템플릿 편집</CardTitle>
+                            <CardDescription>
+                              행사 참가자 안내 마크다운 원문을 저장하면 해당
+                              공개 화면에 바로 반영됩니다.
+                            </CardDescription>
+                          </CardHeader>
+                          <CardContent className="p-7 pt-6">
+                            {isPolicyLoading ? (
+                              <EmptyPanelState
+                                className="min-h-[16rem]"
+                                message="개인정보 처리 문안을 불러오는 중입니다."
+                              />
+                            ) : (
+                              <div className="space-y-3">
+                                <Label htmlFor="policy-template-editor">
+                                  {selectedPolicyOption.label} 마크다운 원문
+                                </Label>
+                                <Textarea
+                                  id="policy-template-editor"
+                                  value={policyDraft}
+                                  onChange={(event) => {
+                                    setPolicyDrafts((currentDrafts) => ({
+                                      ...currentDrafts,
+                                      [selectedPolicyKey]: event.target.value,
+                                    }));
+                                    if (policyNotice) {
+                                      setPolicyNotice("");
+                                    }
+                                  }}
+                                  className="min-h-[20rem] rounded-[1.25rem] border-white/90 bg-white/90 font-mono text-xs leading-6 shadow-none"
+                                  placeholder={`# ${selectedPolicyOption.label}`}
+                                />
+                              </div>
+                            )}
+                          </CardContent>
+                        </Card>
+                      ) : null}
+
+                      <Card className="flex min-h-0 flex-col overflow-hidden rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
                         <CardHeader className="space-y-2 p-7 pb-0">
-                          <CardTitle>템플릿 편집</CardTitle>
+                          <CardTitle>미리보기</CardTitle>
                           <CardDescription>
-                            행사 참가자 안내 마크다운 원문을 저장하면 해당 공개 화면에 바로
-                            반영됩니다.
+                            치환 변수는 미리보기에서 샘플 행사와 DevFactory 기준
+                            값으로 치환됩니다.
                           </CardDescription>
                         </CardHeader>
-                        <CardContent className="p-7 pt-6">
+                        <CardContent className="flex min-h-0 flex-1 flex-col p-7 pt-6">
                           {isPolicyLoading ? (
                             <EmptyPanelState
-                              className="min-h-[16rem]"
+                              className="min-h-[24rem]"
                               message="개인정보 처리 문안을 불러오는 중입니다."
                             />
-                          ) : (
-                            <div className="space-y-3">
-                              <Label htmlFor="policy-template-editor">
-                                {selectedPolicyOption.label} 마크다운 원문
-                              </Label>
-                              <Textarea
-                                id="policy-template-editor"
-                                value={policyDraft}
-                                onChange={(event) => {
-                                  setPolicyDrafts((currentDrafts) => ({
-                                    ...currentDrafts,
-                                    [selectedPolicyKey]: event.target.value,
-                                  }));
-                                  if (policyNotice) {
-                                    setPolicyNotice("");
-                                  }
+                          ) : policyDraft ? (
+                            <div className="min-h-0 flex-1 overflow-y-auto rounded-[1.5rem] border border-white/90 bg-white/90 p-6 pr-7 md:p-8 md:pr-9 [scrollbar-gutter:stable_both-edges]">
+                              <ReactMarkdown
+                                components={{
+                                  h1: ({ children }) => (
+                                    <h1 className="mb-6 text-3xl font-black tracking-tight text-brand-800">
+                                      {children}
+                                    </h1>
+                                  ),
+                                  h2: ({ children }) => (
+                                    <h2 className="mb-4 mt-10 text-xl font-black text-slate-900">
+                                      {children}
+                                    </h2>
+                                  ),
+                                  h3: ({ children }) => (
+                                    <h3 className="mb-3 mt-7 text-lg font-bold text-slate-900">
+                                      {children}
+                                    </h3>
+                                  ),
+                                  p: ({ children }) => (
+                                    <p className="mb-4 whitespace-pre-wrap text-sm leading-7 text-slate-600">
+                                      {children}
+                                    </p>
+                                  ),
+                                  ul: ({ children }) => (
+                                    <ul className="mb-5 list-disc space-y-3 pl-5 text-sm leading-7 text-slate-600">
+                                      {children}
+                                    </ul>
+                                  ),
+                                  ol: ({ children }) => (
+                                    <ol className="mb-5 list-decimal space-y-3 pl-5 text-sm leading-7 text-slate-600">
+                                      {children}
+                                    </ol>
+                                  ),
+                                  li: ({ children }) => (
+                                    <li className="pl-1">{children}</li>
+                                  ),
+                                  strong: ({ children }) => (
+                                    <strong className="font-bold text-slate-900">
+                                      {children}
+                                    </strong>
+                                  ),
                                 }}
-                                className="min-h-[20rem] rounded-[1.25rem] border-white/90 bg-white/90 font-mono text-xs leading-6 shadow-none"
-                                placeholder={`# ${selectedPolicyOption.label}`}
-                              />
+                              >
+                                {policyPreviewContent}
+                              </ReactMarkdown>
                             </div>
+                          ) : (
+                            <EmptyPanelState
+                              className="min-h-[24rem]"
+                              message="아직 표시할 템플릿 내용이 없습니다."
+                            />
                           )}
                         </CardContent>
                       </Card>
-                    ) : null}
-
-                    <Card className="flex min-h-0 flex-col overflow-hidden rounded-[1.75rem] border-[#e8efe0] bg-[#fbfcf8] shadow-none">
-                      <CardHeader className="space-y-2 p-7 pb-0">
-                        <CardTitle>미리보기</CardTitle>
-                        <CardDescription>
-                          치환 변수는 미리보기에서 샘플 행사와 DevFactory 기준 값으로 치환됩니다.
-                        </CardDescription>
-                      </CardHeader>
-                      <CardContent className="flex min-h-0 flex-1 flex-col p-7 pt-6">
-                        {isPolicyLoading ? (
-                          <EmptyPanelState
-                            className="min-h-[24rem]"
-                            message="개인정보 처리 문안을 불러오는 중입니다."
-                          />
-                        ) : policyDraft ? (
-                          <div className="min-h-0 flex-1 overflow-y-auto rounded-[1.5rem] border border-white/90 bg-white/90 p-6 pr-7 md:p-8 md:pr-9 [scrollbar-gutter:stable_both-edges]">
-                            <ReactMarkdown
-                              components={{
-                                h1: ({ children }) => (
-                                  <h1 className="mb-6 text-3xl font-black tracking-tight text-brand-800">
-                                    {children}
-                                  </h1>
-                                ),
-                                h2: ({ children }) => (
-                                  <h2 className="mb-4 mt-10 text-xl font-black text-slate-900">{children}</h2>
-                                ),
-                                h3: ({ children }) => (
-                                  <h3 className="mb-3 mt-7 text-lg font-bold text-slate-900">{children}</h3>
-                                ),
-                                p: ({ children }) => (
-                                  <p className="mb-4 whitespace-pre-wrap text-sm leading-7 text-slate-600">
-                                    {children}
-                                  </p>
-                                ),
-                                ul: ({ children }) => (
-                                  <ul className="mb-5 list-disc space-y-3 pl-5 text-sm leading-7 text-slate-600">
-                                    {children}
-                                  </ul>
-                                ),
-                                ol: ({ children }) => (
-                                  <ol className="mb-5 list-decimal space-y-3 pl-5 text-sm leading-7 text-slate-600">
-                                    {children}
-                                  </ol>
-                                ),
-                                li: ({ children }) => <li className="pl-1">{children}</li>,
-                                strong: ({ children }) => (
-                                  <strong className="font-bold text-slate-900">{children}</strong>
-                                ),
-                              }}
-                            >
-                              {policyPreviewContent}
-                            </ReactMarkdown>
-                          </div>
-                        ) : (
-                          <EmptyPanelState
-                            className="min-h-[24rem]"
-                            message="아직 표시할 템플릿 내용이 없습니다."
-                          />
-                        )}
-                      </CardContent>
-                    </Card>
+                    </div>
                   </div>
-                </div>
-              </>
-            ) : null}
+                </>
+              ) : null}
             </div>
           </CardContent>
         </Card>
@@ -3124,10 +3896,13 @@ const AdminConsolePage = ({
           <div className="mx-auto my-4 flex max-h-[calc(100dvh-4rem)] w-full max-w-3xl flex-col overflow-hidden rounded-[1.75rem] bg-white p-6 shadow-soft sm:my-6 sm:max-h-[calc(100dvh-5rem)] sm:p-7">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-2xl font-black tracking-tight text-brand-800">관리자 추가</h2>
+                <h2 className="text-2xl font-black tracking-tight text-brand-800">
+                  관리자 추가
+                </h2>
                 <p className="mt-2 text-sm text-slate-500">
-                  승인된 이메일로 Google 로그인하면 바로 관리자 페이지에 접속할 수 있습니다.
-                  Gmail이 아니어도 Google 계정에 연결된 이메일이면 사용할 수 있습니다.
+                  승인된 이메일로 Google 로그인하면 바로 관리자 페이지에 접속할
+                  수 있습니다. Gmail이 아니어도 Google 계정에 연결된 이메일이면
+                  사용할 수 있습니다.
                 </p>
               </div>
               <Button
@@ -3143,10 +3918,15 @@ const AdminConsolePage = ({
               </Button>
             </div>
 
-            <form className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden" onSubmit={handleCreateAdmin}>
+            <form
+              className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden"
+              onSubmit={handleCreateAdmin}
+            >
               <div className="min-h-0 flex-1 space-y-5 overflow-y-auto pr-4 [scrollbar-gutter:stable_both-edges]">
                 <div className="space-y-2">
-                  <Label htmlFor="new-admin-email">Google 로그인에 사용할 이메일</Label>
+                  <Label htmlFor="new-admin-email">
+                    Google 로그인에 사용할 이메일
+                  </Label>
                   <Input
                     id="new-admin-email"
                     type="email"
@@ -3160,8 +3940,8 @@ const AdminConsolePage = ({
                     placeholder="organizer@example.com"
                   />
                   <p className="text-xs leading-5 text-slate-500">
-                    승인 후 이 이메일로 Google 로그인합니다. Gmail 주소가 아니어도 Google
-                    계정에 연결되어 있으면 사용할 수 있습니다.
+                    승인 후 이 이메일로 Google 로그인합니다. Gmail 주소가
+                    아니어도 Google 계정에 연결되어 있으면 사용할 수 있습니다.
                   </p>
                 </div>
 
@@ -3183,17 +3963,21 @@ const AdminConsolePage = ({
                 <div className="space-y-2">
                   <Label>권한</Label>
                   <div className="grid grid-cols-2 gap-3">
-                    {([
-                      ["admin", "Admin"],
-                      ["event_manager", "Event manager"],
-                    ] as const).map(([value, label]) => (
+                    {(
+                      [
+                        ["admin", "Admin"],
+                        ["event_manager", "Event manager"],
+                      ] as const
+                    ).map(([value, label]) => (
                       <Button
                         key={value}
-                        variant={newAdminForm.role === value ? "outline" : "secondary"}
+                        variant={
+                          newAdminForm.role === value ? "outline" : "secondary"
+                        }
                         className={cn(
                           "rounded-2xl border-brand-600 bg-white text-base text-brand-700 hover:bg-brand-50",
                           newAdminForm.role !== value &&
-                            "border-transparent bg-brand-50 text-slate-500 hover:bg-brand-100"
+                            "border-transparent bg-brand-50 text-slate-500 hover:bg-brand-100",
                         )}
                         onClick={() =>
                           setNewAdminForm((previousValue) => ({
@@ -3210,7 +3994,11 @@ const AdminConsolePage = ({
               </div>
 
               <div className="mt-5 shrink-0 space-y-4 border-t border-slate-100 pt-4">
-                {addFormError ? <p className="text-sm font-semibold text-rose-600">{addFormError}</p> : null}
+                {addFormError ? (
+                  <p className="text-sm font-semibold text-rose-600">
+                    {addFormError}
+                  </p>
+                ) : null}
 
                 <Button type="submit" className="w-full rounded-xl">
                   확인
@@ -3230,7 +4018,8 @@ const AdminConsolePage = ({
                   {eventForm.id ? "이벤트 수정" : "새 이벤트 등록"}
                 </h2>
                 <p className="mt-2 text-sm text-slate-500">
-                  행사명, 위치, 시간, Event team, 키워드를 행사별로 설정할 수 있습니다.
+                  행사명, 위치, 시간, Event team, 키워드를 행사별로 설정할 수
+                  있습니다.
                 </p>
               </div>
 
@@ -3247,14 +4036,19 @@ const AdminConsolePage = ({
               </Button>
             </div>
 
-            <form className="mt-4 flex min-h-0 flex-1 flex-col overflow-hidden" onSubmit={handleSaveEvent}>
+            <form
+              className="mt-4 flex min-h-0 flex-1 flex-col overflow-hidden"
+              onSubmit={handleSaveEvent}
+            >
               <div className="min-h-0 flex-1 space-y-3.5 overflow-y-auto pr-4 [scrollbar-gutter:stable_both-edges]">
                 <div className="space-y-2">
                   <Label htmlFor="event-modal-name">행사 이름</Label>
                   <Input
                     id="event-modal-name"
                     value={eventForm.name}
-                    onChange={(event) => handleEventNameChange(event.target.value)}
+                    onChange={(event) =>
+                      handleEventNameChange(event.target.value)
+                    }
                     placeholder="행사이름을 적어주세요."
                     className="h-12 rounded-xl"
                   />
@@ -3365,25 +4159,34 @@ const AdminConsolePage = ({
                     {(["3", "5"] as const).map((size) => (
                       <Button
                         key={size}
-                        variant={eventForm.boardSize === size ? "outline" : "secondary"}
+                        variant={
+                          eventForm.boardSize === size ? "outline" : "secondary"
+                        }
                         className={cn(
                           "h-12 rounded-xl border-brand-600 bg-white text-base font-semibold text-slate-700 hover:bg-brand-50",
                           eventForm.boardSize !== size &&
-                            "border-slate-200 bg-white text-slate-400 hover:bg-slate-50"
+                            "border-slate-200 bg-white text-slate-400 hover:bg-slate-50",
                         )}
                         onClick={() =>
                           setEventForm((previousValue) => {
                             const nextGoal =
-                              size === "3" ? "3" : previousValue.bingoMissionCount;
+                              size === "3"
+                                ? "3"
+                                : previousValue.bingoMissionCount;
                             const nextKeywords = selectedKeywordPresetId
-                              ? buildEventKeywordPresetKeywords(selectedKeywordPresetId, size)
+                              ? buildEventKeywordPresetKeywords(
+                                  selectedKeywordPresetId,
+                                  size,
+                                )
                               : clampKeywordList(previousValue.keywords, size);
 
                             return {
                               ...previousValue,
                               boardSize: size,
                               bingoMissionCount:
-                                Number(nextGoal) > Number(size) ? size : nextGoal,
+                                Number(nextGoal) > Number(size)
+                                  ? size
+                                  : nextGoal,
                               keywords: nextKeywords,
                             };
                           })
@@ -3421,15 +4224,19 @@ const AdminConsolePage = ({
                     <div>
                       <Label>키워드 관리</Label>
                       <p className="mt-1 text-xs text-brand-700">
-                        현재 키워드: {keywordAutofillSummary.currentCount}개, 필요 키워드 {keywordAutofillSummary.goalCount}개
+                        현재 키워드: {keywordAutofillSummary.currentCount}개,
+                        필요 키워드 {keywordAutofillSummary.goalCount}개
                       </p>
                       <p className="mt-1 text-xs text-slate-500">
-                        카테고리를 고르면 행사 분위기에 맞는 기본 키워드가 바로 채워집니다.
+                        카테고리를 고르면 행사 분위기에 맞는 기본 키워드가 바로
+                        채워집니다.
                       </p>
                       {keywordAutofillSummary.missingCount > 0 ? (
                         <p className="mt-1 text-xs text-amber-700">
-                          저장 시 부족한 {keywordAutofillSummary.missingCount}개는 &quot;
-                          {keywordAutofillSummary.generatedKeywords[0]}&quot;부터 자동으로 채워집니다.
+                          저장 시 부족한 {keywordAutofillSummary.missingCount}
+                          개는 &quot;
+                          {keywordAutofillSummary.generatedKeywords[0]}
+                          &quot;부터 자동으로 채워집니다.
                         </p>
                       ) : (
                         <p className="mt-1 text-xs text-emerald-700">
@@ -3444,7 +4251,9 @@ const AdminConsolePage = ({
                         size="sm"
                         className="h-7 rounded-md bg-emerald-100 px-3 text-[0.72rem] font-bold text-emerald-800 hover:bg-emerald-200"
                         onClick={() =>
-                          setIsKeywordPresetPanelOpen((previousValue) => !previousValue)
+                          setIsKeywordPresetPanelOpen(
+                            (previousValue) => !previousValue,
+                          )
                         }
                       >
                         {isKeywordPresetPanelOpen
@@ -3458,10 +4267,14 @@ const AdminConsolePage = ({
                         size="sm"
                         className="h-7 rounded-md bg-brand-100 px-3 text-[0.72rem] font-bold text-brand-800 hover:bg-brand-200"
                         onClick={() =>
-                          setIsImportEventPanelOpen((previousValue) => !previousValue)
+                          setIsImportEventPanelOpen(
+                            (previousValue) => !previousValue,
+                          )
                         }
                       >
-                        {isImportEventPanelOpen ? "가져오기 닫기" : "기존 행사에서 가져오기"}
+                        {isImportEventPanelOpen
+                          ? "가져오기 닫기"
+                          : "기존 행사에서 가져오기"}
                       </Button>
                       <Button
                         size="sm"
@@ -3484,7 +4297,8 @@ const AdminConsolePage = ({
                     <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 px-3 py-3">
                       <div className="flex flex-wrap gap-2">
                         {EVENT_KEYWORD_PRESET_OPTIONS.map((preset) => {
-                          const isSelected = selectedKeywordPresetId === preset.id;
+                          const isSelected =
+                            selectedKeywordPresetId === preset.id;
 
                           return (
                             <button
@@ -3494,9 +4308,11 @@ const AdminConsolePage = ({
                                 "rounded-full border px-3 py-1.5 text-sm font-semibold transition-colors",
                                 isSelected
                                   ? "border-emerald-500 bg-emerald-600 text-white"
-                                  : "border-emerald-200 bg-white text-emerald-900 hover:border-emerald-300"
+                                  : "border-emerald-200 bg-white text-emerald-900 hover:border-emerald-300",
                               )}
-                              onClick={() => handleApplyKeywordPreset(preset.id)}
+                              onClick={() =>
+                                handleApplyKeywordPreset(preset.id)
+                              }
                             >
                               {preset.label}
                             </button>
@@ -3527,7 +4343,9 @@ const AdminConsolePage = ({
                             setSelectedKeywordPresetId("");
                             setEventForm((previousValue) => ({
                               ...previousValue,
-                              keywords: previousValue.keywords.filter((item) => item !== keyword),
+                              keywords: previousValue.keywords.filter(
+                                (item) => item !== keyword,
+                              ),
                             }));
                           }}
                         >
@@ -3559,7 +4377,11 @@ const AdminConsolePage = ({
                           addKeyword(event.currentTarget.value);
                         }}
                         onKeyDown={handleKeywordDraftKeyDown}
-                        placeholder={eventForm.keywords.length === 0 ? "키워드를 입력하고 Enter를 누르세요." : ""}
+                        placeholder={
+                          eventForm.keywords.length === 0
+                            ? "키워드를 입력하고 Enter를 누르세요."
+                            : ""
+                        }
                         className="min-w-[10rem] flex-1 border-0 bg-transparent px-2 py-1 text-sm text-slate-700 outline-none"
                       />
                     </div>
@@ -3569,7 +4391,9 @@ const AdminConsolePage = ({
                     <div className="rounded-2xl border border-dashed border-brand-200 bg-brand-50/70 px-4 py-4">
                       <div>
                         <div>
-                          <p className="text-sm font-bold text-slate-900">기존 행사 키워드 가져오기</p>
+                          <p className="text-sm font-bold text-slate-900">
+                            기존 행사 키워드 가져오기
+                          </p>
                           <p className="mt-1 text-xs text-slate-600">
                             가져올 행사를 먼저 선택한 뒤 키워드를 불러오세요.
                           </p>
@@ -3579,15 +4403,22 @@ const AdminConsolePage = ({
                       {availableImportEvents.length > 0 ? (
                         <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-end">
                           <div className="flex-1 space-y-2">
-                            <Label htmlFor="event-modal-import-source">가져올 행사</Label>
+                            <Label htmlFor="event-modal-import-source">
+                              가져올 행사
+                            </Label>
                             <select
                               id="event-modal-import-source"
                               value={importSourceEventId}
-                              onChange={(event) => setImportSourceEventId(event.target.value)}
+                              onChange={(event) =>
+                                setImportSourceEventId(event.target.value)
+                              }
                               className="h-12 w-full rounded-xl border border-input bg-background px-3 text-sm text-slate-900 outline-none transition-colors focus:border-brand-500"
                             >
                               {availableImportEvents.map((eventItem) => (
-                                <option key={eventItem.id} value={String(eventItem.id)}>
+                                <option
+                                  key={eventItem.id}
+                                  value={String(eventItem.id)}
+                                >
                                   {`${eventItem.name} · ${formatEventRowDate(eventItem.startAt)} · ${eventItem.boardSize}x${eventItem.boardSize}`}
                                 </option>
                               ))}
@@ -3611,11 +4442,15 @@ const AdminConsolePage = ({
                   ) : null}
 
                   {keywordRecommendationNotice ? (
-                    <p className="text-xs font-semibold text-sky-700">{keywordRecommendationNotice}</p>
+                    <p className="text-xs font-semibold text-sky-700">
+                      {keywordRecommendationNotice}
+                    </p>
                   ) : null}
 
                   {keywordRecommendationError ? (
-                    <p className="text-xs font-semibold text-rose-600">{keywordRecommendationError}</p>
+                    <p className="text-xs font-semibold text-rose-600">
+                      {keywordRecommendationError}
+                    </p>
                   ) : null}
                 </div>
 
@@ -3639,10 +4474,15 @@ const AdminConsolePage = ({
 
               <div className="mt-4 shrink-0 space-y-3 border-t border-slate-100 pt-4">
                 {eventFormError ? (
-                  <p className="text-sm font-semibold text-rose-600">{eventFormError}</p>
+                  <p className="text-sm font-semibold text-rose-600">
+                    {eventFormError}
+                  </p>
                 ) : null}
 
-                <Button type="submit" className="h-12 w-full rounded-xl text-lg font-bold">
+                <Button
+                  type="submit"
+                  className="h-12 w-full rounded-xl text-lg font-bold"
+                >
                   확인
                 </Button>
               </div>
@@ -3655,10 +4495,16 @@ const AdminConsolePage = ({
 };
 
 export const AdminRoutesLoginPage = LoginPage;
-export const AdminDashboardPage = () => <AdminConsolePage section="dashboard" />;
+export const AdminDashboardPage = () => (
+  <AdminConsolePage section="dashboard" />
+);
 export const AdminMembersPage = () => <AdminConsolePage section="members" />;
-export const AdminApplicationsPage = () => <AdminConsolePage section="applications" />;
-export const AdminEventSettingsPage = () => <AdminConsolePage section="event-settings" />;
+export const AdminApplicationsPage = () => (
+  <AdminConsolePage section="applications" />
+);
+export const AdminEventSettingsPage = () => (
+  <AdminConsolePage section="event-settings" />
+);
 export const AdminEventOverviewPage = () => (
   <AdminConsolePage section="event-settings" eventDetailTab="overview" />
 );

--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -1,5 +1,4 @@
 import {
-  Fragment,
   type FormEvent,
   type KeyboardEvent,
   type ReactNode,

--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -2675,13 +2675,25 @@ const AdminConsolePage = ({
                             </div>
                           </div>
 
-                          <div className="min-w-0 rounded-2xl bg-[#f7fbf2] px-4 py-3">
-                            <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
-                              행사 목적
-                            </p>
-                            <p className="mt-2 line-clamp-2 text-sm font-semibold leading-6 text-slate-600">
-                              {requestItem.eventPurpose}
-                            </p>
+                          <div className="min-w-0 space-y-3 rounded-2xl bg-[#f7fbf2] px-4 py-3">
+                            <div>
+                              <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
+                                행사 목적
+                              </p>
+                              <p className="mt-2 line-clamp-2 text-sm font-semibold leading-6 text-slate-600">
+                                {requestItem.eventPurpose}
+                              </p>
+                            </div>
+                            {requestItem.notes ? (
+                              <div className="border-t border-lime-100 pt-3">
+                                <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">
+                                  요청 메모
+                                </p>
+                                <p className="mt-2 line-clamp-2 text-sm font-semibold leading-6 text-slate-600">
+                                  {requestItem.notes}
+                                </p>
+                              </div>
+                            ) : null}
                           </div>
 
                           <div className="text-sm font-semibold text-slate-500">
@@ -2704,6 +2716,11 @@ const AdminConsolePage = ({
                                 {requestItem.reviewedAt
                                   ? ` · ${formatAdminDate(requestItem.reviewedAt)}`
                                   : ""}
+                              </p>
+                            ) : null}
+                            {requestItem.reviewNote ? (
+                              <p className="mt-2 line-clamp-2 text-xs font-semibold leading-5 text-slate-500">
+                                검토 메모: {requestItem.reviewNote}
                               </p>
                             ) : null}
                           </div>


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: 관리자 이벤트 관리 UX 개선

## Impact Trigger (Select At Least One)
- [ ] Cross-domain change (BE/FE/Infra)
- [ ] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [ ] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [x] docs/reference/design-guide.md (if applicable)
- [ ] docs/reference/agent-collaboration.md

## Changes
- 관리자 이벤트 상세 화면의 개요, 대시보드, 참가자, 공유 탭 UI 위계를 개선했습니다.
- 이벤트 개요 탭에서 행사 핵심 정보, 빙고 설정, 키워드 정보를 카드 단위로 분리했습니다.
- 대시보드 핵심 지표와 보조 지표의 시각적 우선순위를 조정했습니다.
- 빙고 정보, 키워드 선택 현황, 참가자 목록에 정렬 기능을 추가했습니다.
- 신청 관리 화면을 반응형 카드 리스트로 변경해 승인/반려 버튼이 가로 스크롤 없이 보이도록 했습니다.
- 관리자 내비게이션을 개선했습니다.
  - 데스크톱 사이드바 폭 축소
  - 모바일 상단 compact 메뉴 적용
  - 서비스 홈 링크 추가
- QR 공유 탭의 버튼 위계와 링크 확인 동선을 정리했습니다.

## Validation
- Tests:
  - `npm run test`
  - `npm run build`
  - 백엔드 `/health` 확인
- Result:
  - `npm run test`: 13개 테스트 파일, 60개 테스트 통과
  - `npm run build`: 통과
  - `/health`: `{"status":"ok"}`
- Not run and reason:
  - E2E 테스트는 실행하지 않았습니다. 변경 범위가 관리자 UI 레이아웃/상호작용 개선에 한정되어 단위 테스트와 빌드 검증을 우선 수행했습니다.

## Guide Sync Check
- [ ] Updated Korean mirrors for changed English guides

## Handoff
- [ ] Added handoff note following docs/templates/agent-handoff.md