### PR TITLE
fix(backend): 이벤트 매니저 이벤트 접근 범위 제한

### DIFF
--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -150,7 +150,18 @@ async def serialize_policy_template(
 
 
 def can_edit_event(actor: Admin, event: Event) -> bool:
+    return can_view_event(actor, event)
+
+
+def can_view_event(actor: Admin, event: Event) -> bool:
     return actor.role == AdminRole.ADMIN or actor.id == event.admin_id
+
+
+def filter_visible_admin_events(actor: Admin, events: list[Event]) -> list[Event]:
+    if actor.role == AdminRole.ADMIN:
+        return events
+
+    return [event for event in events if event.admin_id == actor.id]
 
 
 def validate_event_schedule(start_at: datetime, end_at: datetime) -> None:

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -31,7 +31,9 @@ from .console_services import (
     build_event_detail,
     build_event_rooms,
     can_edit_event,
+    can_view_event,
     ensure_admin_console_seed_data,
+    filter_visible_admin_events,
     kick_event_attendee,
     normalize_event_keywords,
     reset_event_runtime_data,
@@ -372,7 +374,7 @@ async def list_admin_events(
     from .schema import AdminEventSummary
 
     await ensure_admin_console_seed_data(db)
-    events = await Event.get_all(db)
+    events = filter_visible_admin_events(actor, await Event.get_all(db))
 
     if not events:
         return AdminEventListResponse(ok=True, message="이벤트 목록을 불러왔습니다.", events=[])
@@ -451,6 +453,12 @@ async def get_admin_event(
         event = await Event.get_by_id(db, event_id)
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    if not can_view_event(actor, event):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="이 이벤트를 조회할 권한이 없습니다.",
+        )
 
     return AdminEventDetailResponse(
         ok=True,
@@ -584,6 +592,12 @@ async def list_admin_event_rooms(
         event = await Event.get_by_id(db, event_id)
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    if not can_view_event(actor, event):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="이 이벤트를 조회할 권한이 없습니다.",
+        )
 
     rooms = await build_event_rooms(db, event)
     return AdminRoomListResponse(

--- a/backend/app/tests/test_admin_console_services.py
+++ b/backend/app/tests/test_admin_console_services.py
@@ -5,6 +5,8 @@ from api.admin.console_services import (
     build_archive_participant_alias,
     build_admin_event_bingo_progress_query,
     build_admin_console_link,
+    can_view_event,
+    filter_visible_admin_events,
     is_event_personal_data_expired,
     normalize_event_keywords,
     resolve_participant_email,
@@ -33,6 +35,31 @@ def test_build_admin_event_bingo_progress_query_matches_event_and_user():
 
     assert "bingo_boards.user_id = event_attendees.user_id" in statement
     assert "bingo_boards.event_id = event_attendees.event_id" in statement
+
+
+def test_filter_visible_admin_events_allows_admin_to_see_all_events():
+    actor = type("AdminStub", (), {"id": 1, "role": AdminRole.ADMIN})()
+    events = [
+        type("EventStub", (), {"id": 10, "admin_id": 1})(),
+        type("EventStub", (), {"id": 20, "admin_id": 2})(),
+    ]
+
+    assert filter_visible_admin_events(actor, events) == events
+
+
+def test_filter_visible_admin_events_limits_event_manager_to_owned_events():
+    actor = type("AdminStub", (), {"id": 2, "role": AdminRole.EVENT_MANAGER})()
+    owned_event = type("EventStub", (), {"id": 20, "admin_id": 2})()
+    other_event = type("EventStub", (), {"id": 30, "admin_id": 3})()
+
+    assert filter_visible_admin_events(actor, [owned_event, other_event]) == [owned_event]
+
+
+def test_can_view_event_blocks_event_manager_from_other_owner_event():
+    actor = type("AdminStub", (), {"id": 2, "role": AdminRole.EVENT_MANAGER})()
+    event = type("EventStub", (), {"admin_id": 3})()
+
+    assert can_view_event(actor, event) is False
 
 
 def test_normalize_event_keywords_autofills_remaining_slots():


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: N/A
- 이벤트 매니저가 본인 소유가 아닌 이벤트까지 조회할 수 있던 권한 범위 이슈를 수정합니다.

## Impact Trigger (Select At Least One)
- [ ] Cross-domain change (BE/FE/Infra)
- [x] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [x] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [x] BE (`backend/**`)
- [ ] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [x] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [ ] docs/reference/agent-collaboration.md

## Changes
- `GET /api/admin/events`에서 이벤트 매니저는 본인 `admin_id` 이벤트만 응답하도록 제한했습니다.
- `GET /api/admin/events/{event_id}` 직접 접근 시 타인 이벤트는 403으로 차단합니다.
- `GET /api/admin/events/{event_id}/rooms`도 동일한 조회 권한을 적용합니다.
- 권한 필터 단위 테스트를 추가했습니다.

## Validation
- Tests: `PYTHONPATH=app /home/ubuntu/miniconda3/envs/bingo/bin/pytest app/tests`
- Result: 114 passed, 2 skipped
- Not run and reason: N/A

## Guide Sync Check
- [ ] Updated Korean mirrors for changed English guides
- 문서 변경 없음

## Handoff
- [ ] Added handoff note following docs/templates/agent-handoff.md
- 단일 BE 권한 버그 수정으로 PR 본문에 완료 메모를 남깁니다.
