### PR TITLE
[codex] fix mobile bingo QA flows

### DIFF
--- a/frontend/e2e/auth-and-setup.spec.ts
+++ b/frontend/e2e/auth-and-setup.spec.ts
@@ -58,3 +58,21 @@ test("opens name setup first and completes initial keyword setup", async ({ page
   ).length;
   expect(selectedCount).toBe(3);
 });
+
+test("opens name setup after waiting on the countdown screen", async ({ page }) => {
+  const startAt = new Date(Date.now() + 1000).toISOString();
+  const endAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  await mockPublicEventProfile(page, "bingo-networking", { startAt, endAt });
+  await seedBingoSession(page, {
+    userId: 7,
+    userName: "구글 닉네임",
+    loginId: "ABCD12",
+  });
+  await mockEmptyBoardBootstrap(page, 7);
+
+  await page.goto("/event/bingo-networking/bingo");
+
+  await expect(page.getByRole("heading", { name: "빙고 오픈까지 조금만 기다려 주세요" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "이름 설정" })).toBeVisible({ timeout: 4000 });
+});

--- a/frontend/e2e/exchange.spec.ts
+++ b/frontend/e2e/exchange.spec.ts
@@ -97,7 +97,27 @@ test.describe("mobile touch", () => {
 
     await openExchangePage({ page });
     await page.getByLabel("상대방 이름 검색").tap();
-    await selectOpponent(page);
+    await page.getByLabel("상대방 이름 검색").fill("상대");
+    const resultButton = page.getByRole("button", { name: "상대방" });
+    await expect(resultButton).toBeVisible();
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const result = Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "상대방"
+          );
+          if (!result) {
+            return "";
+          }
+
+          const rect = result.getBoundingClientRect();
+          return document
+            .elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
+            ?.textContent?.trim();
+        })
+      )
+      .toBe("상대방");
+    await resultButton.tap();
     await page.getByRole("button", { name: "보내기" }).tap();
 
     await expect(page.locator(".bingo-toast__title")).toHaveText("키워드를 전송했어요");

--- a/frontend/e2e/support/bingoApi.ts
+++ b/frontend/e2e/support/bingoApi.ts
@@ -58,10 +58,14 @@ export const mockPrivacyTemplate = async (page: Page) => {
 
 export const mockPublicEventProfile = async (
   page: Page,
-  eventSlug = "bingo-networking"
+  eventSlug = "bingo-networking",
+  options: {
+    startAt?: string;
+    endAt?: string;
+  } = {}
 ) => {
-  const startAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-  const endAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const startAt = options.startAt ?? new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const endAt = options.endAt ?? new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
   await page.route(`**/api/events/${eventSlug}`, async (route) => {
     await fulfillJson(route, {
@@ -240,12 +244,14 @@ export const mockEmptyBoardBootstrap = async (page: Page, userId: number) => {
 export const mockBoardBootstrap = async ({
   page,
   userId,
+  displayName = "테스터",
   selectedValues,
   activeValues = [],
   interactions = [],
 }: {
   page: Page;
   userId: number;
+  displayName?: string;
   selectedValues: string[];
   activeValues?: string[];
   interactions?: JsonBody[];
@@ -255,6 +261,7 @@ export const mockBoardBootstrap = async ({
       ok: true,
       message: "ok",
       user_id: userId,
+      display_name: displayName,
       board_data: buildBoardData({
         selectedValues,
         activeValues,

--- a/frontend/src/modules/Bingo/BingoGame.css
+++ b/frontend/src/modules/Bingo/BingoGame.css
@@ -594,6 +594,7 @@
 
 .bingo-hero__content {
   position: relative;
+  isolation: isolate;
   min-height: 11.5rem;
   margin-top: 0.78rem;
 }
@@ -602,6 +603,7 @@
   position: relative;
   z-index: 2;
   min-width: 0;
+  padding-right: clamp(7rem, 28%, 13rem);
 }
 
 .bingo-hero__copy h1 {
@@ -619,6 +621,7 @@
   gap: 0.5rem;
   position: relative;
   z-index: 3;
+  isolation: isolate;
   width: min(100%, 31rem);
   margin-top: 0.95rem;
   padding: 0.35rem;
@@ -629,7 +632,7 @@
 
 .bingo-hero__form-field {
   position: relative;
-  z-index: 10;
+  z-index: 30;
   flex: 1 1 0%;
   min-width: 0;
 }
@@ -717,7 +720,10 @@
 
 .bingo-hero__form button {
   position: relative;
-  z-index: 11;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: 0 0 auto;
   max-width: 100%;
   border: 0;
@@ -729,6 +735,8 @@
   font-size: 1.08rem;
   font-weight: 900;
   letter-spacing: -0.04em;
+  line-height: 1;
+  white-space: nowrap;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
   box-shadow: 0 14px 24px rgba(52, 168, 131, 0.22);
@@ -769,7 +777,7 @@
   max-width: none;
   height: auto;
   pointer-events: none;
-  z-index: 1;
+  z-index: 0;
 }
 
 @media (min-width: 961px) {
@@ -1723,6 +1731,10 @@
     min-height: 0;
   }
 
+  .bingo-hero__copy {
+    padding-right: 0;
+  }
+
   .bingo-hero__illustration {
     display: none;
   }
@@ -1737,7 +1749,19 @@
     font-size: 1rem;
   }
 
+  .bingo-hero__form {
+    flex-direction: column;
+    align-items: stretch;
+    border-radius: 1.3rem;
+    padding: 0.45rem;
+  }
+
+  .bingo-hero__form-field {
+    width: 100%;
+  }
+
   .bingo-hero__form button {
+    width: 100%;
     min-width: 6.3rem;
     padding: 0.8rem 1.1rem;
     font-size: 1rem;
@@ -1879,15 +1903,7 @@
     font-size: 0.88rem;
   }
 
-  .bingo-hero__form {
-    flex-direction: column;
-    align-items: stretch;
-    border-radius: 1.3rem;
-    padding: 0.45rem;
-  }
-
   .bingo-hero__form button {
-    width: 100%;
     min-width: 0;
   }
 

--- a/frontend/src/modules/Bingo/BingoGame.tsx
+++ b/frontend/src/modules/Bingo/BingoGame.tsx
@@ -6,6 +6,7 @@ import {
   getBingoBoard,
   getUserAllInteraction,
   searchBingoParticipants,
+  updateBingoDisplayName,
 } from "../../api/bingo_api.ts";
 import type { BingoParticipantItem } from "../../api/bingo_api.ts";
 import {
@@ -136,6 +137,7 @@ const BingoGame = () => {
   const [displayName, setDisplayName] = useState("");
   const [isSearching, setIsSearching] = useState(false);
   const [nameSetupOpen, setNameSetupOpen] = useState(false);
+  const [nameSetupMode, setNameSetupMode] = useState<"new-board" | "existing-board">("new-board");
   const [nameInput, setNameInput] = useState("");
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const opponentInputRef = useRef<HTMLInputElement | null>(null);
@@ -503,7 +505,7 @@ const BingoGame = () => {
       }
 
       // 빙고 오픈 전이면 카운트다운만 표시 (API 호출 안 함)
-      if (!testModeEnabled && Date.now() < unlockTime) {
+      if (locked) {
         setIsBootstrapping(false);
         return;
       }
@@ -529,10 +531,16 @@ const BingoGame = () => {
             window.sessionStorage.setItem(getBoardReadyStorageKey(eventSlug, storedId), "1");
             setHasKnownBoardForEvent(true);
           }
-          if (boardResult.displayName) {
-            setDisplayName(boardResult.displayName);
-            setUsername(boardResult.displayName);
-            syncSessionDisplayName(boardResult.displayName);
+          const resolvedDisplayName = (boardResult.displayName ?? "").trim();
+          if (resolvedDisplayName) {
+            setDisplayName(resolvedDisplayName);
+            setUsername(resolvedDisplayName);
+            syncSessionDisplayName(resolvedDisplayName);
+          } else {
+            setDisplayName("");
+            setNameInput(storedName.trim() && storedName !== "사용자 이름" ? storedName : "");
+            setNameSetupMode("existing-board");
+            setNameSetupOpen(true);
           }
           setBingoBoard(boardData);
           bingoBoardRef.current = boardData;
@@ -576,6 +584,7 @@ const BingoGame = () => {
     };
 
     const enterSetupFlow = (storedName: string) => {
+      setNameSetupMode("new-board");
       const shuffledValues = shuffleArray(cellValues);
       const initialBoard: BingoCell[] = Array(boardCellCount)
         .fill(null)
@@ -599,11 +608,11 @@ const BingoGame = () => {
     eventHomePath,
     eventSlug,
     isEventProfileAvailable,
+    locked,
     navigate,
     showAlert,
     syncSessionDisplayName,
     testModeEnabled,
-    unlockTime,
   ]);
 
   useEffect(() => {
@@ -981,14 +990,36 @@ const BingoGame = () => {
     const trimmed = nameInput.trim();
     if (trimmed.length === 0) {
       showAlert("이름을 입력해주세요.", "warning");
-      return;
+      return false;
     }
 
-    // 이름은 보드 생성 시 함께 전달되므로 여기서는 로컬 상태만 설정
+    const storedId = getAuthSession()?.userId;
+    if (nameSetupMode === "existing-board") {
+      if (!storedId || !eventSlug) {
+        showAlert("로그인 정보가 없습니다.", "error");
+        return false;
+      }
+
+      const result = await updateBingoDisplayName(storedId, eventSlug, trimmed);
+      if (!result.ok) {
+        showAlert(result.message || "이름 저장 중 문제가 발생했습니다.", "error");
+        return false;
+      }
+
+      const nextName = (result.display_name ?? trimmed).trim();
+      setUsername(nextName);
+      setDisplayName(nextName);
+      syncSessionDisplayName(nextName);
+      setNameInput(nextName);
+      return true;
+    }
+
+    // 새 보드는 보드 생성 시 display_name을 함께 전달한다.
     setUsername(trimmed);
     setDisplayName(trimmed);
     syncSessionDisplayName(trimmed);
     setNameInput(trimmed);
+    return true;
   };
 
   const handleExchange = async () => {
@@ -1129,16 +1160,20 @@ const BingoGame = () => {
               <button
                 type="button"
                 className="keyword-setup-submit"
-                onClick={() => {
-                  handleSaveName();
-                  if (nameInput.trim().length > 0) {
-                    setNameSetupOpen(false);
+                onClick={async () => {
+                  const saved = await handleSaveName();
+                  if (!saved) {
+                    return;
+                  }
+
+                  setNameSetupOpen(false);
+                  if (nameSetupMode === "new-board") {
                     setInitialSetupOpen(true);
                   }
                 }}
                 disabled={nameInput.trim().length === 0}
               >
-                다음
+                {nameSetupMode === "existing-board" ? "저장" : "다음"}
               </button>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- Keep the bingo page in the name setup flow when an existing board has no display name, and persist the entered name through the display-name API.
- Re-run the post-countdown bootstrap when the event unlocks so users who waited before open time do not skip setup.
- Stabilize the mobile exchange search/send form layout so search results stay above the send button and remain tappable.
- Update Playwright helpers and coverage for existing-board display names, countdown-to-name-setup, and mobile search-result hit testing.

## Validation
- `npm run build`
- `npm run test -- src/modules/Bingo/bingoGameUtils.test.ts src/modules/Bingo/bingoSessionState.test.ts`
- `npx playwright test e2e/auth-and-setup.spec.ts e2e/exchange.spec.ts`