### PR TITLE
[codex] Fix bingo keyword exchange feedback

### DIFF
--- a/frontend/e2e/exchange.spec.ts
+++ b/frontend/e2e/exchange.spec.ts
@@ -66,7 +66,7 @@ test("sends keywords from an existing bingo session", async ({ page }) => {
   await page.getByRole("button", { name: "보내기" }).click();
 
   await expect(page.locator(".bingo-toast__title")).toHaveText("키워드를 전송했어요");
-  await expect(page.getByText('"상대방"님에게 새로운 키워드를 전송했어요.')).toBeVisible();
+  await expect(page.getByText('"상대방"님에게 내 키워드를 전송했어요.')).toBeVisible();
   await expect(page.locator(".history-panel").first()).toContainText("상대방");
   await expect(page.getByLabel("상대방 이름 검색")).toHaveValue("");
 });
@@ -183,6 +183,7 @@ test("shows an error and allows retrying the exchange", async ({ page }) => {
           receiveUserId: 9,
           sendUserName: session.userName,
           receiveUserName: "상대방",
+          wordIdList: JSON.stringify(selectedValues),
           updatedWords: ["키워드 1", "키워드 2"],
         })
       ),
@@ -199,8 +200,9 @@ test("shows an error and allows retrying the exchange", async ({ page }) => {
 
   await page.getByRole("button", { name: "보내기" }).click();
 
-  await expect(page.locator(".bingo-toast__title")).toHaveText("새 키워드만 전송했어요");
-  await expect(page.getByText('"상대방"님이 이미 가진 키워드는 제외하고 새로운 키워드만 전송했어요.')).toBeVisible();
+  await expect(page.locator(".bingo-toast__title")).toHaveText("키워드를 전송했어요");
+  await expect(page.getByText('"상대방"님에게 내 키워드를 전송했어요.')).toBeVisible();
+  await expect(page.locator(".bingo-toast__keywords")).toContainText("키워드 3");
   await expect(page.locator(".history-panel").first()).toContainText("상대방");
   await expect(page.getByLabel("상대방 이름 검색")).toHaveValue("");
   expect(requestCount).toBe(2);

--- a/frontend/src/modules/Bingo/BingoGame.tsx
+++ b/frontend/src/modules/Bingo/BingoGame.tsx
@@ -53,6 +53,7 @@ import {
   getCompletedLines,
   getDefaultAlertTitle,
   getBingoMissionProgressPercent,
+  getInteractionKeywords,
   getLatestIncomingBatch,
   getLatestInteractionId,
   getUniqueKeywords,
@@ -1086,33 +1087,18 @@ const BingoGame = () => {
       setOpponentId("");
       setOpponentQuery("");
 
-      const deliverableKeywords = getUniqueKeywords(exchangeResult.updatedWords);
+      const sentKeywords = getUniqueKeywords(
+        getInteractionKeywords(exchangeResult.interaction)
+      );
       const receiverName =
         exchangeResult.interaction.receive_user_name ?? `참가자 ${targetId}`;
 
-      if (deliverableKeywords.length > 0) {
-        showAlert(
-          deliverableKeywords.length === myKeywords.length
-            ? `"${receiverName}"님에게 새로운 키워드를 전송했어요.`
-            : `"${receiverName}"님이 이미 가진 키워드는 제외하고 새로운 키워드만 전송했어요.`,
-          "success",
-          {
-            title:
-              deliverableKeywords.length === myKeywords.length
-                ? "키워드를 전송했어요"
-                : "새 키워드만 전송했어요",
-            keywords: deliverableKeywords,
-            label: "KEYWORD EXCHANGE",
-          }
-        );
-        return;
-      }
-
       showAlert(
-        `"${receiverName}"님은 이미 내 키워드를 모두 가지고 있어요.`,
-        "info",
+        `"${receiverName}"님에게 내 키워드를 전송했어요.`,
+        "success",
         {
-          title: "이미 키워드가 다 있어요",
+          title: "키워드를 전송했어요",
+          keywords: sentKeywords,
           label: "KEYWORD EXCHANGE",
         }
       );

--- a/frontend/src/modules/Bingo/bingoGameUtils.test.ts
+++ b/frontend/src/modules/Bingo/bingoGameUtils.test.ts
@@ -114,12 +114,13 @@ describe("buildIncomingKeywordAlert", () => {
     signature: "12:2026-03-19T10:00:01.000Z:AI|ML",
   };
 
-  it("returns an info alert when the receiver already has every keyword", () => {
+  it("returns all sent keywords when the receiver already has every keyword", () => {
     expect(buildIncomingKeywordAlert(incomingBatch, [])).toEqual({
-      message: "\"민지\"님이 보낸 키워드는 이미 모두 가지고 있어요.",
-      severity: "info",
+      message: "\"민지\"님이 키워드를 보내줬어요. 새로 추가된 키워드는 없어요.",
+      severity: "success",
       payload: {
-        title: "이미 키워드가 다 있어요",
+        title: "키워드를 받았어요",
+        keywords: ["AI", "ML"],
         label: "KEYWORD EXCHANGE",
       },
     });
@@ -131,6 +132,18 @@ describe("buildIncomingKeywordAlert", () => {
       severity: "success",
       payload: {
         title: "새 키워드를 받았어요",
+        keywords: ["AI", "ML"],
+        label: "KEYWORD EXCHANGE",
+      },
+    });
+  });
+
+  it("keeps all sent keywords visible when only new keywords update the board", () => {
+    expect(buildIncomingKeywordAlert(incomingBatch, ["AI"])).toEqual({
+      message: "\"민지\"님이 키워드를 보내줬어요. 받은 키워드를 보드에 반영했어요.",
+      severity: "success",
+      payload: {
+        title: "키워드를 받았어요",
         keywords: ["AI", "ML"],
         label: "KEYWORD EXCHANGE",
       },

--- a/frontend/src/modules/Bingo/bingoGameUtils.ts
+++ b/frontend/src/modules/Bingo/bingoGameUtils.ts
@@ -124,10 +124,11 @@ export const buildIncomingKeywordAlert = (
 
   if (newlyUpdatedValues.length === 0) {
     return {
-      message: `"${displaySenderName}"님이 보낸 키워드는 이미 모두 가지고 있어요.`,
-      severity: "info",
+      message: `"${displaySenderName}"님이 키워드를 보내줬어요. 새로 추가된 키워드는 없어요.`,
+      severity: "success",
       payload: {
-        title: "이미 키워드가 다 있어요",
+        title: "키워드를 받았어요",
+        keywords: latestIncomingBatch.keywords,
         label: "KEYWORD EXCHANGE",
       },
     };
@@ -146,11 +147,11 @@ export const buildIncomingKeywordAlert = (
   }
 
   return {
-    message: `"${displaySenderName}"님이 보낸 키워드 중 새로운 항목만 반영했어요.`,
+    message: `"${displaySenderName}"님이 키워드를 보내줬어요. 받은 키워드를 보드에 반영했어요.`,
     severity: "success",
     payload: {
-      title: "새 키워드만 반영했어요",
-      keywords: newlyUpdatedValues,
+      title: "키워드를 받았어요",
+      keywords: latestIncomingBatch.keywords,
       label: "KEYWORD EXCHANGE",
     },
   };


### PR DESCRIPTION
## What changed
- Show the full sent keyword list from word_id_list after a keyword exchange succeeds.
- Keep already-owned keywords visible in receiver alerts while only applying new keywords to the board.
- Update exchange E2E and bingo utility tests to cover the partial-update case.

## Why
QA found that already-owned keywords looked like they were excluded from the exchange. The backend records the full exchange, but the frontend used updated_words as the displayed sent list. updated_words only represents board cells newly checked on the receiver board.

## Validation
- npm test -- --run src/modules/Bingo/bingoGameUtils.test.ts
- npm run build
- npm run e2e -- e2e/exchange.spec.ts