### PR TITLE
에이전트 PR 언어 규칙 동기화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Last-Validated: 2026-03-22
 - what changed
 - how it was verified
 - next impact or follow-up if any
+- PR title and body must be written in Korean unless the reviewer explicitly requests another language.
 
 ## Domain Ownership And Merge Policy
 - BE domain: `backend/**`
@@ -113,4 +114,3 @@ Last-Validated: 2026-03-22
 - Product Owner defines scope, acceptance criteria, sequencing, and major risk mitigations.
 - Backend and Frontend implement in parallel when possible.
 - QA validates service-page scenarios first, then admin scenarios.
-


### PR DESCRIPTION
## 작업 요약
- `docs/reference/agent-collaboration.md`에 있던 PR 제목/본문 한국어 작성 규칙을 `AGENTS.md`에도 반영했습니다.
- worktree 격리 및 Team Lead Mode 관련 규칙은 이미 동기화되어 있어 추가 변경하지 않았습니다.

## 검증
- 문서 설정 변경만 포함되어 별도 테스트는 실행하지 않았습니다.
- `git diff`로 변경 범위를 확인했습니다.

## 참고
- 작업은 `/home/ubuntu/.openclaw/workspace-bingo-agent-settings-sync` 분리 worktree에서 진행했습니다.
