### PR TITLE
관리자 모바일 경고 표시 조건 수정

### DIFF
--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -187,8 +187,14 @@ const shouldShowAdminMobileNotice = () => {
     return false;
   }
 
+  const isNarrowViewport = window.matchMedia("(max-width: 1279px)").matches;
+  const isCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
+  const cannotHover = window.matchMedia("(hover: none)").matches;
+  const hasTouchPoints = window.navigator.maxTouchPoints > 0;
+
   return (
-    window.matchMedia("(max-width: 1279px)").matches &&
+    isNarrowViewport &&
+    (isCoarsePointer || cannotHover || hasTouchPoints) &&
     window.sessionStorage.getItem(ADMIN_MOBILE_NOTICE_STORAGE_KEY) !== "true"
   );
 };
@@ -1246,20 +1252,24 @@ const AdminConsolePage = ({
       return;
     }
 
-    const mediaQuery = window.matchMedia("(max-width: 1279px)");
+    const mediaQueries = [
+      window.matchMedia("(max-width: 1279px)"),
+      window.matchMedia("(pointer: coarse)"),
+      window.matchMedia("(hover: none)"),
+    ];
     const handleChange = () => {
-      setShowMobileNotice(
-        mediaQuery.matches &&
-          window.sessionStorage.getItem(ADMIN_MOBILE_NOTICE_STORAGE_KEY) !==
-            "true",
-      );
+      setShowMobileNotice(shouldShowAdminMobileNotice());
     };
 
     handleChange();
-    mediaQuery.addEventListener("change", handleChange);
+    mediaQueries.forEach((mediaQuery) => {
+      mediaQuery.addEventListener("change", handleChange);
+    });
 
     return () => {
-      mediaQuery.removeEventListener("change", handleChange);
+      mediaQueries.forEach((mediaQuery) => {
+        mediaQuery.removeEventListener("change", handleChange);
+      });
     };
   }, []);
 


### PR DESCRIPTION
## 작업 요약
- 관리자 페이지 모바일 경고가 데스크톱 브라우저 창을 작게 줄였을 때도 뜨던 문제를 수정했습니다.
- 기존 viewport 폭 기준에 더해 `pointer: coarse`, `hover: none`, `navigator.maxTouchPoints` 신호를 함께 확인하도록 변경했습니다.
- 실제 모바일/태블릿에서는 경고를 유지하고, PC에서 창 크기만 줄인 경우에는 경고가 뜨지 않도록 했습니다.

## 검증
- `npm run lint` 통과
- `npm test -- Admin` 통과, 3 files / 9 tests

## 참고
- 작업은 `/home/ubuntu/.openclaw/workspace-bingo-admin-mobile-warning` 분리 worktree에서 진행했습니다.
