### PR TITLE
랜딩 행사 사례 카드에 규모 표시 추가

### DIFF
--- a/frontend/e2e/landing-page.spec.ts
+++ b/frontend/e2e/landing-page.spec.ts
@@ -63,6 +63,9 @@ test("landing page keeps the experience and admin entry points prominent", async
   await expect(page.getByText("Korea Business Experimentation Symposium 2025").first()).toBeVisible();
   await expect(page.getByText("PseudoCon 2025").first()).toBeVisible();
   await expect(page.getByText("8th PseudoCon").first()).toBeVisible();
+  await expect(page.getByText("100명 규모").first()).toBeVisible();
+  await expect(page.getByText("200명 규모").first()).toBeVisible();
+  await expect(page.getByText("200명+ 규모").first()).toBeVisible();
 
   await page.getByLabel("이름").fill("홍길동");
   await page.getByLabel("Google 로그인에 사용할 이메일").fill("organizer@example.com");

--- a/frontend/src/modules/Landing/components/EventPosterCard.tsx
+++ b/frontend/src/modules/Landing/components/EventPosterCard.tsx
@@ -1,4 +1,5 @@
 import {
+  EVENT_CASE_ATTENDEE_SCALE_LABELS,
   type EventCase,
   formatEventCaseDate,
   POSTER_THEMES,
@@ -26,19 +27,21 @@ const EventPosterCard = ({ event, index }: EventPosterCardProps) => {
 
   return (
     <article
-      className="animate-soft-rise group flex h-full flex-col overflow-hidden rounded-[2rem] border border-white/70 bg-white/85 shadow-soft transition-shadow duration-300 hover:shadow-lg"
-      style={{ animationDelay: `${index * 70}ms` }}
+      className="group flex h-full flex-col overflow-hidden rounded-[2rem] border border-white/70 bg-white/85 shadow-soft transition-shadow duration-300 hover:shadow-lg"
     >
       {/* Poster */}
       <div className={`relative flex min-h-[18rem] flex-1 flex-col justify-between overflow-hidden bg-gradient-to-br ${theme.bg} px-6 py-6`}>
-        <div aria-hidden="true">
+        <div aria-hidden="true" className="pointer-events-none absolute inset-0">
           <PosterDecoration accent={theme.accent} />
         </div>
         <div className="relative z-10 flex flex-col items-start">
-          <div className="flex min-h-24 items-start">
+          <div className="flex min-h-32 flex-col items-start gap-2">
             <h3 className={`text-xl font-bold leading-tight tracking-tight ${theme.text}`}>
               {event.name}
             </h3>
+            <p className={`text-sm font-bold leading-5 ${theme.sub}`}>
+              {EVENT_CASE_ATTENDEE_SCALE_LABELS[event.attendeeScale]}
+            </p>
           </div>
         </div>
         <div className="relative z-10">

--- a/frontend/src/modules/Landing/utils/landingHelpers.ts
+++ b/frontend/src/modules/Landing/utils/landingHelpers.ts
@@ -35,11 +35,21 @@ export type PosterTheme = (typeof POSTER_THEMES)[number];
 
 /* ── Fixed Event Cases ───────────────────────────────────── */
 
+export type EventCaseAttendeeScale = "50" | "100" | "200" | "200+";
+
+export const EVENT_CASE_ATTENDEE_SCALE_LABELS: Record<EventCaseAttendeeScale, string> = {
+  "50": "50명 규모",
+  "100": "100명 규모",
+  "200": "200명 규모",
+  "200+": "200명+ 규모",
+};
+
 export type EventCase = {
   id: string;
   name: string;
   startAt: string;
   place: string;
+  attendeeScale: EventCaseAttendeeScale;
   tags: string[];
 };
 
@@ -49,6 +59,7 @@ export const EVENT_CASES: EventCase[] = [
     name: "2025 Product DNA Open Forum",
     startAt: "2025-10-25T00:00:00+09:00",
     place: "한빛미디어 리더스홀",
+    attendeeScale: "100",
     tags: ["인과추론", "프로덕트 분석", "데이터 분석가"],
   },
   {
@@ -56,6 +67,7 @@ export const EVENT_CASES: EventCase[] = [
     name: "Korea Business Experimentation Symposium 2025",
     startAt: "2025-07-12T00:00:00+09:00",
     place: "고려대학교 LG-POSCO 경영관",
+    attendeeScale: "100",
     tags: ["비즈니스 실험", "데이터 분석", "연구자"],
   },
   {
@@ -63,6 +75,7 @@ export const EVENT_CASES: EventCase[] = [
     name: "PseudoCon 2025",
     startAt: "2025-05-17T00:00:00+09:00",
     place: "서울창업허브 공덕 10층",
+    attendeeScale: "200+",
     tags: ["AI/DS", "오픈소스", "개발자"],
   },
   {
@@ -70,6 +83,7 @@ export const EVENT_CASES: EventCase[] = [
     name: "8th PseudoCon",
     startAt: "2024-06-15T00:00:00+09:00",
     place: "마이크로소프트 광화문 본사 13층",
+    attendeeScale: "200",
     tags: ["AI 엔지니어", "연구개발자", "GenAI"],
   },
 ];


### PR DESCRIPTION
## 요약
- Task ID: landing-event-scale
- 관련 이슈: #207 (처리 완료 및 닫힘)

## Impact Trigger
- 해당 없음: FE 단일 도메인의 랜딩 UI 표시 변경입니다.

## 영향 범위
- [ ] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [x] docs/reference/design-guide.md
- [ ] docs/reference/agent-collaboration.md

## 변경 사항
- 랜딩 행사 사례 데이터에 모집/예상 규모 구간 필드를 추가했습니다.
- 신청서 규모 단위에 맞춰 `100명 규모`, `200명 규모`, `200명+ 규모`를 행사명 아래에 표시합니다.
- 배경 장식 요소가 카드 flex 레이아웃 정렬에 영향을 주지 않도록 수정했습니다.
- 랜딩 E2E에 규모 문구 노출 검증을 추가했습니다.

## 검증
- Tests: `npm run build`, `npx playwright test e2e/landing-page.spec.ts`
- Result: 통과
- Not run and reason: 해당 없음

## Guide Sync Check
- [x] 문서 변경 없음. Korean mirror 업데이트 불필요.

## Handoff
- [x] 경미한 FE 단일 도메인 변경으로 별도 handoff 문서 생략.

## 디자인/레이아웃 확인
- Caddy 연결 개발 화면에서 행사명/규모/태그/날짜 정렬을 확인했습니다.
- 행사 사례 카드 제목 시작선은 배경 장식 요소를 absolute 처리하여 카드별로 동일하게 맞췄습니다.