### PR TITLE
feat: 홈페이지와 데모 이벤트 로그 수집 기반 추가

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -8,6 +8,7 @@ from api.integrations.routes import router as integrations_router
 from api.review.routes import review_router
 from api.admin.routes import admin_router
 from api.play.routes import play_router
+from api.analytics.routes import analytics_router
 
 api_router = APIRouter(prefix="/api")
 
@@ -20,6 +21,7 @@ routers = [
     review_router,
     admin_router,
     play_router,
+    analytics_router,
 ]
 
 for router in routers:

--- a/backend/app/api/analytics/__init__.py
+++ b/backend/app/api/analytics/__init__.py
@@ -1,0 +1,3 @@
+from .routes import analytics_router
+
+__all__ = ["analytics_router"]

--- a/backend/app/api/analytics/routes.py
+++ b/backend/app/api/analytics/routes.py
@@ -1,0 +1,273 @@
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from core.db import AsyncSessionDepends
+from models.site_analytics_event import SiteAnalyticsEvent
+
+from .schema import (
+    AnalyticsEventCreateItem,
+    AnalyticsEventCreateRequest,
+    AnalyticsEventCreateResponse,
+)
+
+
+analytics_router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+ALLOWED_EVENT_NAMES = {
+    "homepage_viewed",
+    "homepage_section_viewed",
+    "homepage_cta_clicked",
+    "admin_login_clicked",
+    "application_form_viewed",
+    "application_form_started",
+    "application_validation_failed",
+    "application_submit_clicked",
+    "application_submitted",
+    "demo_keyword_selection_viewed",
+    "demo_keyword_selection_ready",
+    "demo_start_clicked",
+    "demo_game_viewed",
+    "demo_exchange_advanced",
+    "demo_goal_completed",
+    "demo_replay_clicked",
+    "demo_invalid_game_entry_redirected",
+    "site_route_changed",
+    "site_session_checkpoint",
+}
+
+ALLOWED_ROUTES = {"/", "/demo/play", "/demo/play/game"}
+ALLOWED_EVENT_SOURCES = {"frontend"}
+ALLOWED_DEVICE_CLASSES = {"mobile", "tablet", "desktop"}
+ALLOWED_VIEWPORT_BUCKETS = {"mobile", "tablet", "desktop-sm", "desktop-md", "desktop-lg"}
+ALLOWED_REFERRER_TYPES = {"direct", "internal", "external", "unknown"}
+HOST_ENVIRONMENT_MAP = {
+    "bingo.pseudolab-devfactory.com": ("production", "bingo", True),
+    "bingo-private.pseudolab-devfactory.com": ("private_dev", "bingo-private", False),
+    "localhost": ("local", "localhost", False),
+    "127.0.0.1": ("local", "localhost", False),
+    "0.0.0.0": ("local", "localhost", False),
+    "::1": ("local", "localhost", False),
+}
+LOCAL_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+DISALLOWED_PROPERTY_KEYS = {
+    "email",
+    "name",
+    "phone",
+    "user_email",
+    "user_name",
+    "participant_name",
+    "sender_name",
+    "receiver_name",
+    "event_name",
+    "event_slug",
+    "free_text",
+    "raw_url",
+    "raw_query",
+    "raw_user_agent",
+    "user_agent",
+    "ip",
+    "ip_address",
+    "text",
+    "query",
+    "search",
+    "purpose",
+    "notes",
+}
+
+
+def normalize_hostname(hostname: str) -> str:
+    return hostname.strip().lower().strip("[]")
+
+
+def resolve_environment(hostname: str) -> tuple[str, str, bool]:
+    normalized_hostname = normalize_hostname(hostname)
+    if normalized_hostname not in HOST_ENVIRONMENT_MAP:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 analytics hostname입니다.",
+        )
+    return HOST_ENVIRONMENT_MAP[normalized_hostname]
+
+
+def resolve_header_hostname(request: Request) -> str | None:
+    origin_or_referer = request.headers.get("origin") or request.headers.get("referer")
+    if not origin_or_referer:
+        return None
+
+    parsed = urlparse(origin_or_referer)
+    if not parsed.hostname:
+        return None
+    return normalize_hostname(parsed.hostname)
+
+
+def validate_origin_hostname(payload_hostname: str, request: Request) -> None:
+    header_hostname = resolve_header_hostname(request)
+    if not header_hostname:
+        return
+
+    if header_hostname not in HOST_ENVIRONMENT_MAP:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="허용되지 않은 analytics origin입니다.",
+        )
+
+    payload_hostname = normalize_hostname(payload_hostname)
+    if header_hostname == payload_hostname:
+        return
+    if header_hostname in LOCAL_HOSTS and payload_hostname in LOCAL_HOSTS:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="analytics origin과 hostname이 일치하지 않습니다.",
+    )
+
+
+def validate_safe_properties(value: Any, path: str = "properties") -> None:
+    if isinstance(value, dict):
+        if len(value) > 60:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{path} 항목 수가 너무 많습니다.",
+            )
+        for key, nested_value in value.items():
+            normalized_key = str(key).strip().lower()
+            if normalized_key in DISALLOWED_PROPERTY_KEYS or normalized_key.startswith("raw_"):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"개인정보 또는 원문 로그로 판단되는 필드는 저장할 수 없습니다: {path}.{key}",
+                )
+            validate_safe_properties(nested_value, f"{path}.{key}")
+        return
+
+    if isinstance(value, list):
+        if len(value) > 30:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{path} 배열 길이가 너무 깁니다.",
+            )
+        for index, nested_value in enumerate(value):
+            validate_safe_properties(nested_value, f"{path}[{index}]")
+        return
+
+    if isinstance(value, str):
+        if len(value) > 300:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{path} 문자열이 너무 깁니다.",
+            )
+        if EMAIL_PATTERN.match(value.strip()):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"이메일 형식 값은 analytics properties에 저장할 수 없습니다: {path}",
+            )
+        return
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"지원하지 않는 analytics property 타입입니다: {path}",
+    )
+
+
+def validate_analytics_event_payload(payload: AnalyticsEventCreateRequest, request: Request) -> dict[str, Any]:
+    if payload.event_name not in ALLOWED_EVENT_NAMES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 analytics event_name입니다.",
+        )
+    if payload.event_source not in ALLOWED_EVENT_SOURCES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 analytics event_source입니다.",
+        )
+    if payload.route not in ALLOWED_ROUTES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 analytics route입니다.",
+        )
+    if payload.device_class not in ALLOWED_DEVICE_CLASSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 device_class입니다.",
+        )
+    if payload.viewport_bucket not in ALLOWED_VIEWPORT_BUCKETS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 viewport_bucket입니다.",
+        )
+    if payload.referrer_type not in ALLOWED_REFERRER_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="허용되지 않은 referrer_type입니다.",
+        )
+
+    validate_origin_hostname(payload.hostname, request)
+    environment, deployment_channel, is_production_domain = resolve_environment(payload.hostname)
+    if (
+        payload.environment != environment
+        or payload.deployment_channel != deployment_channel
+        or payload.is_production_domain != is_production_domain
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="analytics hostname 환경 정보가 일치하지 않습니다.",
+        )
+
+    validate_safe_properties(payload.properties)
+    validate_safe_properties({"experiments": payload.experiments})
+
+    return {
+        "event_id": payload.event_id,
+        "schema_version": payload.schema_version,
+        "event_name": payload.event_name,
+        "event_source": payload.event_source,
+        "analytics_session_id": payload.analytics_session_id,
+        "page_view_id": payload.page_view_id,
+        "occurred_at": payload.occurred_at,
+        "app_version": payload.app_version,
+        "route": payload.route,
+        "hostname": normalize_hostname(payload.hostname),
+        "environment": environment,
+        "deployment_channel": deployment_channel,
+        "is_production_domain": is_production_domain,
+        "viewport_bucket": payload.viewport_bucket,
+        "device_class": payload.device_class,
+        "referrer_type": payload.referrer_type,
+        "properties": payload.properties,
+        "experiments": payload.experiments,
+    }
+
+
+@analytics_router.post(
+    "/events",
+    response_model=AnalyticsEventCreateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="홈페이지 및 데모 analytics 이벤트 수집",
+)
+async def create_analytics_event(
+    payload: AnalyticsEventCreateRequest,
+    request: Request,
+    db: AsyncSessionDepends,
+):
+    create_kwargs = validate_analytics_event_payload(payload, request)
+    existing_event = await SiteAnalyticsEvent.get_by_event_id(db, payload.event_id)
+    if existing_event:
+        return AnalyticsEventCreateResponse(
+            ok=True,
+            message="이미 수집된 analytics 이벤트입니다.",
+            event=AnalyticsEventCreateItem(event_id=payload.event_id, status="duplicate"),
+        )
+
+    created_event = await SiteAnalyticsEvent.create(db, **create_kwargs)
+    return AnalyticsEventCreateResponse(
+        ok=True,
+        message="analytics 이벤트를 수집했습니다.",
+        event=AnalyticsEventCreateItem(event_id=created_event.event_id, status="accepted"),
+    )

--- a/backend/app/api/analytics/schema.py
+++ b/backend/app/api/analytics/schema.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from core.base_schema import BaseSchema
+
+
+class AnalyticsEventCreateRequest(BaseModel):
+    event_id: str = Field(..., min_length=8, max_length=80)
+    schema_version: int = Field(..., ge=1, le=1)
+    event_name: str = Field(..., min_length=3, max_length=80)
+    event_source: str = Field(..., min_length=3, max_length=32)
+    analytics_session_id: str = Field(..., min_length=8, max_length=80)
+    page_view_id: str = Field(..., min_length=8, max_length=80)
+    occurred_at: datetime
+    app_version: Optional[str] = Field(default=None, max_length=120)
+    route: str = Field(..., min_length=1, max_length=120)
+    hostname: str = Field(..., min_length=1, max_length=253)
+    environment: str = Field(..., min_length=1, max_length=32)
+    deployment_channel: str = Field(..., min_length=1, max_length=32)
+    is_production_domain: bool
+    viewport_bucket: str = Field(..., min_length=1, max_length=32)
+    device_class: str = Field(..., min_length=1, max_length=32)
+    referrer_type: str = Field(..., min_length=1, max_length=32)
+    properties: dict[str, Any] = Field(default_factory=dict)
+    experiments: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class AnalyticsEventCreateItem(BaseModel):
+    event_id: str
+    status: str
+
+
+class AnalyticsEventCreateResponse(BaseSchema):
+    event: AnalyticsEventCreateItem

--- a/backend/app/migrations/versions/8f4b2d9c1a30_add_site_analytics_events.py
+++ b/backend/app/migrations/versions/8f4b2d9c1a30_add_site_analytics_events.py
@@ -1,0 +1,74 @@
+"""add site analytics events table
+
+Revision ID: 8f4b2d9c1a30
+Revises: 3b9c1f0d2a77
+Create Date: 2026-05-18 01:20:00.000000+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "8f4b2d9c1a30"
+down_revision: Union[str, None] = "3b9c1f0d2a77"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    existing_tables = set(inspector.get_table_names())
+
+    if "site_analytics_events" in existing_tables:
+        return
+
+    op.create_table(
+        "site_analytics_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.String(length=80), nullable=False),
+        sa.Column("schema_version", sa.Integer(), nullable=False),
+        sa.Column("event_name", sa.String(length=80), nullable=False),
+        sa.Column("event_source", sa.String(length=32), nullable=False),
+        sa.Column("analytics_session_id", sa.String(length=80), nullable=False),
+        sa.Column("page_view_id", sa.String(length=80), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("app_version", sa.String(length=120), nullable=True),
+        sa.Column("route", sa.String(length=120), nullable=False),
+        sa.Column("hostname", sa.String(length=253), nullable=False),
+        sa.Column("environment", sa.String(length=32), nullable=False),
+        sa.Column("deployment_channel", sa.String(length=32), nullable=False),
+        sa.Column("is_production_domain", sa.Boolean(), nullable=False),
+        sa.Column("viewport_bucket", sa.String(length=32), nullable=False),
+        sa.Column("device_class", sa.String(length=32), nullable=False),
+        sa.Column("referrer_type", sa.String(length=32), nullable=False),
+        sa.Column("properties", sa.JSON(), nullable=False),
+        sa.Column("experiments", sa.JSON(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", name="uq_site_analytics_events_event_id"),
+    )
+    op.create_index(
+        "ix_site_analytics_events_name_occurred_at",
+        "site_analytics_events",
+        ["event_name", "occurred_at"],
+    )
+    op.create_index(
+        "ix_site_analytics_events_hostname_route_occurred_at",
+        "site_analytics_events",
+        ["hostname", "route", "occurred_at"],
+    )
+    op.create_index(
+        "ix_site_analytics_events_session",
+        "site_analytics_events",
+        ["analytics_session_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_site_analytics_events_session", table_name="site_analytics_events")
+    op.drop_index("ix_site_analytics_events_hostname_route_occurred_at", table_name="site_analytics_events")
+    op.drop_index("ix_site_analytics_events_name_occurred_at", table_name="site_analytics_events")
+    op.drop_table("site_analytics_events")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,3 +7,4 @@ from models.event_manager_request import EventManagerRequest, EventManagerReques
 from models.room import Room
 from models.team import Team, TeamColor
 from models.event_attendee import EventAttendee
+from models.site_analytics_event import SiteAnalyticsEvent

--- a/backend/app/models/site_analytics_event.py
+++ b/backend/app/models/site_analytics_event.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import Boolean, DateTime, Integer, JSON, String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.db import AsyncSession
+from models.base import Base
+
+
+class SiteAnalyticsEvent(Base):
+    __tablename__ = "site_analytics_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
+    event_id: Mapped[str] = mapped_column(String(80), nullable=False, unique=True)
+    schema_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    event_source: Mapped[str] = mapped_column(String(32), nullable=False)
+    analytics_session_id: Mapped[str] = mapped_column(String(80), nullable=False)
+    page_view_id: Mapped[str] = mapped_column(String(80), nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(ZoneInfo("Asia/Seoul")),
+        nullable=False,
+    )
+    app_version: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    route: Mapped[str] = mapped_column(String(120), nullable=False)
+    hostname: Mapped[str] = mapped_column(String(253), nullable=False)
+    environment: Mapped[str] = mapped_column(String(32), nullable=False)
+    deployment_channel: Mapped[str] = mapped_column(String(32), nullable=False)
+    is_production_domain: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    viewport_bucket: Mapped[str] = mapped_column(String(32), nullable=False)
+    device_class: Mapped[str] = mapped_column(String(32), nullable=False)
+    referrer_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    properties: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    experiments: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
+
+    @classmethod
+    async def get_by_event_id(
+        cls,
+        session: AsyncSession,
+        event_id: str,
+    ) -> Optional["SiteAnalyticsEvent"]:
+        result = await session.execute(select(cls).where(cls.event_id == event_id))
+        return result.scalar_one_or_none()
+
+    @classmethod
+    async def create(
+        cls,
+        session: AsyncSession,
+        **kwargs: Any,
+    ) -> "SiteAnalyticsEvent":
+        event = cls(**kwargs)
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        return event

--- a/backend/app/tests/test_analytics_routes.py
+++ b/backend/app/tests/test_analytics_routes.py
@@ -1,0 +1,116 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import api.analytics.routes as analytics_routes
+from api.analytics.routes import analytics_router, validate_analytics_event_payload
+from api.analytics.schema import AnalyticsEventCreateRequest
+
+
+def _request_payload(**overrides):
+    payload = {
+        "event_id": "event-123456",
+        "schema_version": 1,
+        "event_name": "homepage_viewed",
+        "event_source": "frontend",
+        "analytics_session_id": "session-123456",
+        "page_view_id": "page-123456",
+        "occurred_at": datetime(2026, 5, 18, tzinfo=timezone.utc),
+        "route": "/",
+        "hostname": "bingo.pseudolab-devfactory.com",
+        "environment": "production",
+        "deployment_channel": "bingo",
+        "is_production_domain": True,
+        "viewport_bucket": "desktop-lg",
+        "device_class": "desktop",
+        "referrer_type": "direct",
+        "properties": {"entry_path": "/", "section_id": "hero"},
+        "experiments": [],
+    }
+    payload.update(overrides)
+    return AnalyticsEventCreateRequest(**payload)
+
+
+def _request(headers=None):
+    return SimpleNamespace(headers=headers or {})
+
+
+def test_analytics_router_exposes_event_collection_endpoint():
+    paths = {route.path for route in analytics_router.routes}
+
+    assert "/analytics/events" in paths
+
+
+def test_validate_analytics_event_payload_accepts_production_domain():
+    validated = validate_analytics_event_payload(
+        _request_payload(),
+        _request(headers={"origin": "https://bingo.pseudolab-devfactory.com"}),
+    )
+
+    assert validated["hostname"] == "bingo.pseudolab-devfactory.com"
+    assert validated["environment"] == "production"
+    assert validated["deployment_channel"] == "bingo"
+    assert validated["is_production_domain"] is True
+
+
+def test_validate_analytics_event_payload_rejects_unknown_hostname():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_analytics_event_payload(
+            _request_payload(
+                hostname="example.com",
+                environment="unknown",
+                deployment_channel="other",
+                is_production_domain=False,
+            ),
+            _request(),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_analytics_event_payload_rejects_mismatched_origin():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_analytics_event_payload(
+            _request_payload(),
+            _request(headers={"origin": "https://bingo-private.pseudolab-devfactory.com"}),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+def test_validate_analytics_event_payload_rejects_personal_information_properties():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_analytics_event_payload(
+            _request_payload(properties={"email": "organizer@example.com"}),
+            _request(),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_create_analytics_event_returns_duplicate_without_second_insert(monkeypatch):
+    calls = {"create": 0}
+
+    async def fake_get_by_event_id(_session, event_id):
+        return SimpleNamespace(event_id=event_id)
+
+    async def fake_create(_session, **_kwargs):
+        calls["create"] += 1
+
+    monkeypatch.setattr(analytics_routes.SiteAnalyticsEvent, "get_by_event_id", fake_get_by_event_id)
+    monkeypatch.setattr(analytics_routes.SiteAnalyticsEvent, "create", fake_create)
+
+    response = asyncio.run(
+        analytics_routes.create_analytics_event(
+            _request_payload(),
+            _request(headers={"origin": "https://bingo.pseudolab-devfactory.com"}),
+            object(),
+        )
+    )
+
+    assert response.ok is True
+    assert response.event.status == "duplicate"
+    assert calls["create"] == 0

--- a/frontend/src/components/LandingNavbar.tsx
+++ b/frontend/src/components/LandingNavbar.tsx
@@ -1,7 +1,10 @@
 import { Link } from "react-router-dom";
 import { getAdminPath } from "../config/eventProfiles";
+import { useSiteAnalytics } from "../modules/Landing/siteAnalytics";
 
 const LandingNavbar = () => {
+  const { track } = useSiteAnalytics();
+
   return (
     <>
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg focus:text-brand-700 focus:font-bold">
@@ -19,6 +22,13 @@ const LandingNavbar = () => {
           </a>
           <Link
             to={getAdminPath()}
+            onClick={() =>
+              track("admin_login_clicked", {
+                section_id: "nav",
+                cta_id: "nav_admin_login",
+                cta_destination: getAdminPath(),
+              })
+            }
             className="inline-flex rounded-lg bg-brand-700 hover:bg-brand-800 text-white text-sm font-bold px-3 py-2 transition-colors sm:px-4"
           >
             관리자 로그인

--- a/frontend/src/components/PublicFooter.tsx
+++ b/frontend/src/components/PublicFooter.tsx
@@ -1,10 +1,15 @@
 import { Link } from "react-router-dom";
+import { useSiteAnalytics, useSiteSectionExposure } from "../modules/Landing/siteAnalytics";
 
 const linkClassName =
   "inline-flex min-h-8 items-center rounded-lg text-sm font-bold leading-5 text-slate-300 transition-colors hover:text-mint-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-mint-200";
 
-const PublicFooter = () => (
-  <footer className="relative z-10 border-t border-white/10 bg-slate-950 text-white">
+const PublicFooter = () => {
+  const footerRef = useSiteSectionExposure<HTMLElement>("footer", 3);
+  const { track } = useSiteAnalytics();
+
+  return (
+  <footer ref={footerRef} className="relative z-10 border-t border-white/10 bg-slate-950 text-white">
     <div className="mx-auto grid max-w-7xl gap-8 px-5 py-8 sm:px-6 md:grid-cols-[minmax(0,1fr)_auto] md:gap-10 md:py-10 lg:px-10">
       <div className="max-w-sm">
         <div className="mb-3 flex items-center gap-2">
@@ -26,10 +31,34 @@ const PublicFooter = () => (
       <div className="grid grid-cols-1 gap-x-5 gap-y-6 text-sm sm:grid-cols-2 md:min-w-[22rem] md:gap-8">
         <nav aria-label="정책" className="grid content-start gap-1">
           <p className="text-sm font-black text-slate-100">정책</p>
-          <Link to="/terms" target="_blank" rel="noreferrer" className={linkClassName}>
+          <Link
+            to="/terms"
+            target="_blank"
+            rel="noreferrer"
+            className={linkClassName}
+            onClick={() =>
+              track("homepage_cta_clicked", {
+                cta_id: "footer_terms",
+                cta_destination: "/terms",
+                section_id: "footer",
+              })
+            }
+          >
             이용약관
           </Link>
-          <Link to="/privacy" target="_blank" rel="noreferrer" className={linkClassName}>
+          <Link
+            to="/privacy"
+            target="_blank"
+            rel="noreferrer"
+            className={linkClassName}
+            onClick={() =>
+              track("homepage_cta_clicked", {
+                cta_id: "footer_privacy",
+                cta_destination: "/privacy",
+                section_id: "footer",
+              })
+            }
+          >
             개인정보처리방침
           </Link>
         </nav>
@@ -43,6 +72,7 @@ const PublicFooter = () => (
       </div>
     </div>
   </footer>
-);
+  );
+};
 
 export default PublicFooter;

--- a/frontend/src/modules/Landing/DemoPlayPage.tsx
+++ b/frontend/src/modules/Landing/DemoPlayPage.tsx
@@ -19,6 +19,7 @@ import {
   createDemoPlayExchangeSteps,
   getDemoPlayBoardVariantIndex,
 } from "./demoPlayUtils";
+import { createAnalyticsId, SiteAnalyticsScope, useSiteAnalytics } from "./siteAnalytics";
 
 type DemoPlayState = {
   board: BingoCell[];
@@ -419,10 +420,11 @@ const DemoBoard = ({
   );
 };
 
-const DemoPlayPage = () => {
+const DemoPlayPageContent = ({ demoRunId }: { demoRunId: string }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { track } = useSiteAnalytics();
   const isGameRoute = location.pathname.endsWith("/game");
   const selectedKeywordsFromQuery = useMemo(() => {
     const keywords = searchParams.get("keywords") ?? "";
@@ -450,6 +452,9 @@ const DemoPlayPage = () => {
     keywords: [] as string[],
   });
   const [isGoalOverlayVisible, setIsGoalOverlayVisible] = useState(true);
+  const hasTrackedReadyRef = useRef(false);
+  const hasTrackedGoalRef = useRef(false);
+  const gameStartedAtRef = useRef(Date.now());
 
   useEffect(() => {
     return () => {
@@ -467,11 +472,25 @@ const DemoPlayPage = () => {
     setSendAlert((currentAlert) => ({ ...currentAlert, open: false }));
     setReceiveBoardAlert((currentAlert) => ({ ...currentAlert, open: false }));
     setIsGoalOverlayVisible(true);
+    hasTrackedReadyRef.current = false;
+    hasTrackedGoalRef.current = false;
+    gameStartedAtRef.current = Date.now();
     if (alertTimeoutRef.current) {
       window.clearTimeout(alertTimeoutRef.current);
       alertTimeoutRef.current = null;
     }
   }, [activeKeywordKey, boardVariantIndex, isGameRoute]);
+
+  useEffect(() => {
+    if (isGameRoute || draftKeywords.length < DEMO_PLAY_MIN_SELECTED_KEYWORDS || hasTrackedReadyRef.current) {
+      return;
+    }
+
+    hasTrackedReadyRef.current = true;
+    track("demo_keyword_selection_ready", {
+      selected_count: draftKeywords.length,
+    });
+  }, [draftKeywords.length, isGameRoute, track]);
 
   const baseBoard = useMemo(
     () =>
@@ -502,12 +521,22 @@ const DemoPlayPage = () => {
     }
 
     setIsGoalOverlayVisible(true);
+    if (!hasTrackedGoalRef.current) {
+      hasTrackedGoalRef.current = true;
+      track("demo_goal_completed", {
+        total_steps: exchangeSteps.length,
+        final_completed_line_count: demoState.completedLines.length,
+        elapsed_ms_from_game_view: Date.now() - gameStartedAtRef.current,
+        demo_run_id: demoRunId,
+        board_layout_variant_id: boardVariantIndex,
+      });
+    }
     const goalOverlayTimer = window.setTimeout(() => {
       setIsGoalOverlayVisible(false);
     }, DEMO_GOAL_OVERLAY_DURATION_MS);
 
     return () => window.clearTimeout(goalOverlayTimer);
-  }, [isComplete]);
+  }, [boardVariantIndex, demoRunId, demoState.completedLines.length, exchangeSteps.length, isComplete, track]);
 
   const nextStep = exchangeSteps[completedStepCount] ?? null;
   const canStart = draftKeywords.length >= DEMO_PLAY_MIN_SELECTED_KEYWORDS;
@@ -559,6 +588,9 @@ const DemoPlayPage = () => {
     if (!canStart) {
       return;
     }
+    track("demo_start_clicked", {
+      selected_count: draftKeywords.length,
+    });
     const keywordQuery = draftKeywords.map(encodeURIComponent).join(",");
     navigate(`/demo/play/game?keywords=${keywordQuery}`);
   };
@@ -591,6 +623,31 @@ const DemoPlayPage = () => {
         setReceiveBoardAlert((currentAlert) => ({ ...currentAlert, open: false }));
         alertTimeoutRef.current = null;
       }, nextStep.senderId === "host" ? DEMO_SEND_ALERT_DURATION_MS : DEMO_RECEIVE_ALERT_DURATION_MS);
+
+      const nextDemoState = buildDemoState(
+        baseBoard,
+        exchangeSteps,
+        Math.min(completedStepCount + 1, exchangeSteps.length)
+      );
+      const nextMetParticipantCount = new Set(
+        exchangeSteps
+          .slice(0, completedStepCount + 1)
+          .map((step) => (step.senderId === "host" ? step.receiverName : step.senderName))
+      ).size;
+      track("demo_exchange_advanced", {
+        step_index: completedStepCount,
+        step_id: nextStep.id,
+        action_type: nextStep.senderId === "host" ? "send" : "receive",
+        sent_keyword_count: nextStep.sentKeywords.length,
+        matched_keyword_count: nextStep.hostReceivedKeywords.length,
+        completed_line_count_after: nextDemoState.completedLines.length,
+        new_line_count: Math.max(
+          0,
+          nextDemoState.completedLines.length - demoState.completedLines.length
+        ),
+        met_participant_count: nextMetParticipantCount,
+        demo_run_id: demoRunId,
+      });
     }
     setCompletedStepCount((currentCount) =>
       Math.min(currentCount + 1, exchangeSteps.length)
@@ -598,6 +655,16 @@ const DemoPlayPage = () => {
   };
 
   const handleReplay = () => {
+    track(
+      "demo_replay_clicked",
+      {
+        completed_step_count: completedStepCount,
+        completed_line_count: demoState.completedLines.length,
+        elapsed_ms_from_game_view: Date.now() - gameStartedAtRef.current,
+        demo_run_id: demoRunId,
+      },
+      { beacon: true }
+    );
     window.location.reload();
   };
 
@@ -610,7 +677,10 @@ const DemoPlayPage = () => {
     }
   };
 
-  if (isGameRoute && selectedKeywordsFromQuery.length < DEMO_PLAY_MIN_SELECTED_KEYWORDS) {
+  const isInvalidGameEntry =
+    isGameRoute && selectedKeywordsFromQuery.length < DEMO_PLAY_MIN_SELECTED_KEYWORDS;
+
+  if (isInvalidGameEntry) {
     return <Navigate to="/demo/play" replace />;
   }
 
@@ -827,6 +897,55 @@ const DemoPlayPage = () => {
         </p>
       </main>
     </PcDesignStage>
+  );
+};
+
+const DemoPlayPage = () => {
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const isGameRoute = location.pathname.endsWith("/game");
+  const selectedKeywordCount = (searchParams.get("keywords") ?? "")
+    .split(",")
+    .map((keyword) => keyword.trim())
+    .filter(Boolean)
+    .filter((keyword, index, list) => list.indexOf(keyword) === index)
+    .slice(0, DEMO_PLAY_MAX_SELECTED_KEYWORDS).length;
+  const route = isGameRoute ? "/demo/play/game" : "/demo/play";
+  const demoRunRef = useRef({ locationKey: location.key, demoRunId: createAnalyticsId() });
+  if (demoRunRef.current.locationKey !== location.key) {
+    demoRunRef.current = { locationKey: location.key, demoRunId: createAnalyticsId() };
+  }
+  const demoRunId = demoRunRef.current.demoRunId;
+  const isInvalidGameEntry = isGameRoute && selectedKeywordCount < DEMO_PLAY_MIN_SELECTED_KEYWORDS;
+  const pageEventName =
+    isInvalidGameEntry
+      ? "demo_invalid_game_entry_redirected"
+      : isGameRoute
+        ? "demo_game_viewed"
+        : "demo_keyword_selection_viewed";
+  const pageProperties = isInvalidGameEntry
+    ? {
+        reason: selectedKeywordCount === 0 ? "missing_keywords" : "insufficient_keywords",
+        keyword_count: selectedKeywordCount,
+      }
+    : isGameRoute
+    ? {
+        demo_run_id: demoRunId,
+        selected_count: selectedKeywordCount,
+      }
+    : {
+        preselected_count: selectedKeywordCount,
+        source_route: "direct_or_previous",
+      };
+
+  return (
+    <SiteAnalyticsScope
+      route={route}
+      pageEventName={pageEventName}
+      pageProperties={pageProperties}
+    >
+      <DemoPlayPageContent demoRunId={demoRunId} />
+    </SiteAnalyticsScope>
   );
 };
 

--- a/frontend/src/modules/Landing/LandingHomePage.tsx
+++ b/frontend/src/modules/Landing/LandingHomePage.tsx
@@ -2,23 +2,26 @@ import LandingNavbar from "../../components/LandingNavbar";
 import EventCatalog from "./components/EventCatalog";
 import HeroSection from "./components/HeroSection";
 import LandingFooter from "./components/LandingFooter";
+import { SiteAnalyticsScope } from "./siteAnalytics";
 
 const LandingHomePage = () => {
   return (
-    <div className="min-h-screen bg-[#f3f8f4] text-slate-900">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_15%_20%,rgba(29,172,121,0.18),transparent_22%),radial-gradient(circle_at_88%_12%,rgba(14,88,63,0.14),transparent_18%),linear-gradient(180deg,#f3f8f4_0%,#e8f1ed_100%)]"
-      />
-      <LandingNavbar />
+    <SiteAnalyticsScope route="/" pageEventName="homepage_viewed" pageProperties={{ entry_path: "/" }}>
+      <div className="min-h-screen bg-[#f3f8f4] text-slate-900">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_15%_20%,rgba(29,172,121,0.18),transparent_22%),radial-gradient(circle_at_88%_12%,rgba(14,88,63,0.14),transparent_18%),linear-gradient(180deg,#f3f8f4_0%,#e8f1ed_100%)]"
+        />
+        <LandingNavbar />
 
-      <main id="main-content">
-        <HeroSection />
-        <EventCatalog />
-      </main>
+        <main id="main-content">
+          <HeroSection />
+          <EventCatalog />
+        </main>
 
-      <LandingFooter />
-    </div>
+        <LandingFooter />
+      </div>
+    </SiteAnalyticsScope>
   );
 };
 

--- a/frontend/src/modules/Landing/components/AdminApplicationForm.tsx
+++ b/frontend/src/modules/Landing/components/AdminApplicationForm.tsx
@@ -1,7 +1,8 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
 import { submitEventManagerApplication } from "../../../api/public_event_api";
 import { Dialog } from "../../../components/ui/dialog";
+import { useSiteAnalytics, useSiteSectionExposure } from "../siteAnalytics";
 
 type ApplicationFormState = {
   name: string;
@@ -28,20 +29,89 @@ const ATTENDEE_RANGE_OPTIONS = [
   { value: "201", label: "201명 이상" },
 ] as const;
 
+const getFilledFieldCount = (form: ApplicationFormState) =>
+  Object.values(form).filter((value) => value.trim().length > 0).length;
+
 const AdminApplicationForm = () => {
   const [form, setForm] = useState<ApplicationFormState>(initialFormState);
   const [formError, setFormError] = useState("");
   const [submitMessage, setSubmitMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const applyRef = useSiteSectionExposure<HTMLDivElement>("apply", 2);
+  const { track } = useSiteAnalytics();
+  const hasTrackedFormViewRef = useRef(false);
+  const hasTrackedFormStartRef = useRef(false);
+  const formStartedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const element = applyRef.current;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && entry.intersectionRatio >= 0.35 && !hasTrackedFormViewRef.current) {
+          hasTrackedFormViewRef.current = true;
+          track("application_form_viewed", { section_id: "apply" });
+          observer.disconnect();
+        }
+      },
+      { threshold: [0.35, 0.6] }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [applyRef, track]);
+
+  const updateFormField = (field: keyof ApplicationFormState, value: string) => {
+    setForm((previousForm) => {
+      const nextForm = { ...previousForm, [field]: value };
+      if (!hasTrackedFormStartRef.current) {
+        hasTrackedFormStartRef.current = true;
+        formStartedAtRef.current = Date.now();
+        track("application_form_started", {
+          field_id: field,
+          filled_field_count: getFilledFieldCount(nextForm),
+        });
+      }
+      return nextForm;
+    });
+  };
+
+  const trackValidationFailure = (fieldId: string, validationErrorType: string) => {
+    track("application_validation_failed", {
+      field_id: fieldId,
+      validation_error_type: validationErrorType,
+    });
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!form.name.trim()) { setFormError("이름을 입력해 주세요."); return; }
+    const filledFieldCount = getFilledFieldCount(form);
+    track("application_submit_clicked", {
+      filled_field_count: filledFieldCount,
+      has_expected_date: Boolean(form.expectedEventDate),
+      has_attendee_range: Boolean(form.expectedAttendeeRange),
+      has_purpose: Boolean(form.eventPurpose.trim()),
+    });
+
+    if (!form.name.trim()) {
+      trackValidationFailure("name", "required");
+      setFormError("이름을 입력해 주세요."); return;
+    }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim().toLowerCase())) {
+      trackValidationFailure("email", "invalid_email");
       setFormError("올바른 이메일 주소를 입력해 주세요."); return;
     }
-    if (!form.eventName.trim()) { setFormError("행사명을 입력해 주세요."); return; }
-    if (!form.expectedAttendeeRange) { setFormError("예상 참가자 수를 선택해 주세요."); return; }
+    if (!form.eventName.trim()) {
+      trackValidationFailure("eventName", "required");
+      setFormError("행사명을 입력해 주세요."); return;
+    }
+    if (!form.expectedAttendeeRange) {
+      trackValidationFailure("expectedAttendeeRange", "required");
+      setFormError("예상 참가자 수를 선택해 주세요."); return;
+    }
     try {
       setIsSubmitting(true);
       setFormError("");
@@ -59,6 +129,10 @@ const AdminApplicationForm = () => {
       setSubmitMessage(
         "입력하신 이메일로 접수 확인 메일을 발송했습니다."
       );
+      track("application_submitted", {
+        elapsed_ms_from_form_start: formStartedAtRef.current ? Date.now() - formStartedAtRef.current : 0,
+        filled_field_count: filledFieldCount,
+      });
       setForm(initialFormState);
     } catch (error) {
       setFormError(error instanceof Error ? error.message : "신청을 접수하지 못했습니다.");
@@ -69,6 +143,7 @@ const AdminApplicationForm = () => {
 
   return (
     <div
+      ref={applyRef}
       id="apply"
       className="bg-white/85 backdrop-blur rounded-[2rem] border border-white/70 shadow-soft px-6 pt-6 pb-4 sm:px-7 sm:pt-7 sm:pb-5 scroll-mt-24 lg:scroll-mt-28"
     >
@@ -90,7 +165,7 @@ const AdminApplicationForm = () => {
               id="app-name"
               type="text"
               value={form.name}
-              onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+              onChange={(e) => updateFormField("name", e.target.value)}
               placeholder="홍길동"
               className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent focus:shadow-sm"
             />
@@ -103,7 +178,7 @@ const AdminApplicationForm = () => {
               id="app-email"
               type="email"
               value={form.email}
-              onChange={(e) => setForm((p) => ({ ...p, email: e.target.value }))}
+              onChange={(e) => updateFormField("email", e.target.value)}
               placeholder="organizer@example.com"
               className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent focus:shadow-sm"
             />
@@ -119,7 +194,7 @@ const AdminApplicationForm = () => {
               id="app-event"
               type="text"
               value={form.eventName}
-              onChange={(e) => setForm((p) => ({ ...p, eventName: e.target.value }))}
+              onChange={(e) => updateFormField("eventName", e.target.value)}
               placeholder="2026 Bingo Networking Day"
               className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent focus:shadow-sm"
             />
@@ -132,7 +207,7 @@ const AdminApplicationForm = () => {
               id="app-date"
               type="date"
               value={form.expectedEventDate}
-              onChange={(e) => setForm((p) => ({ ...p, expectedEventDate: e.target.value }))}
+              onChange={(e) => updateFormField("expectedEventDate", e.target.value)}
               className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent focus:shadow-sm"
             />
           </div>
@@ -145,7 +220,7 @@ const AdminApplicationForm = () => {
           <select
             id="app-attendees"
             value={form.expectedAttendeeRange}
-            onChange={(e) => setForm((p) => ({ ...p, expectedAttendeeRange: e.target.value }))}
+            onChange={(e) => updateFormField("expectedAttendeeRange", e.target.value)}
             className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent focus:shadow-sm"
           >
             <option value="" disabled>
@@ -166,7 +241,7 @@ const AdminApplicationForm = () => {
           <textarea
             id="app-purpose"
             value={form.eventPurpose}
-            onChange={(e) => setForm((p) => ({ ...p, eventPurpose: e.target.value }))}
+            onChange={(e) => updateFormField("eventPurpose", e.target.value)}
             rows={2}
             placeholder="예: 참가자 간 아이스브레이킹, 기술 네트워킹, 후원사 부스 유입 유도 등"
             className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent focus:shadow-sm resize-none"

--- a/frontend/src/modules/Landing/components/EventCatalog.tsx
+++ b/frontend/src/modules/Landing/components/EventCatalog.tsx
@@ -1,10 +1,18 @@
 import EventPosterCard from "./EventPosterCard";
 import { EVENT_CASES } from "../utils/landingHelpers";
 import { scrollToHashTarget } from "../utils/scrollToHashTarget";
+import { useSiteAnalytics, useSiteSectionExposure } from "../siteAnalytics";
 
 const EventCatalog = () => {
+  const eventsRef = useSiteSectionExposure<HTMLElement>("events", 1);
+  const { track } = useSiteAnalytics();
+
   return (
-    <section id="events" className="relative scroll-mt-16 pb-16 pt-14 lg:pb-20 lg:pt-16">
+    <section
+      ref={eventsRef}
+      id="events"
+      className="relative scroll-mt-16 pb-16 pt-14 lg:pb-20 lg:pt-16"
+    >
       <div className="mx-auto max-w-7xl px-6 lg:px-10">
         <div className="animate-soft-rise mb-12 text-center">
           <p className="text-sm font-bold uppercase tracking-[0.22em] text-brand-700 mb-3">
@@ -32,6 +40,11 @@ const EventCatalog = () => {
             href="#apply"
             onClick={(event) => {
               event.preventDefault();
+              track("homepage_cta_clicked", {
+                cta_id: "event_case_apply",
+                cta_destination: "#apply",
+                section_id: "events",
+              });
               scrollToHashTarget("#apply");
             }}
             className="inline-flex items-center gap-2 rounded-full bg-brand-700 hover:bg-brand-800 active:scale-[0.97] text-white px-6 py-3 text-sm font-semibold transition-all"

--- a/frontend/src/modules/Landing/components/HeroSection.tsx
+++ b/frontend/src/modules/Landing/components/HeroSection.tsx
@@ -1,42 +1,55 @@
 import AdminApplicationForm from "./AdminApplicationForm";
+import { useSiteAnalytics, useSiteSectionExposure } from "../siteAnalytics";
 
-const HeroSection = () => (
-  <section className="relative border-b border-slate-100 overflow-hidden">
-    <div
-      className="absolute inset-0 bg-cover bg-center"
-      style={{ backgroundImage: "url('/images/hero-networking.jpg')" }}
-      aria-hidden="true"
-    />
-    <div
-      className="absolute inset-0 bg-gradient-to-r from-slate-900/85 via-slate-900/70 to-slate-900/30"
-      aria-hidden="true"
-    />
+const HeroSection = () => {
+  const heroRef = useSiteSectionExposure<HTMLElement>("hero", 0);
+  const { track } = useSiteAnalytics();
 
-    <div className="relative mx-auto grid max-w-7xl items-start gap-12 px-6 py-16 lg:grid-cols-[1.1fr_0.9fr] lg:px-10 lg:py-20">
-      {/* Left — headline + CTA */}
-      <div className="animate-soft-rise space-y-6">
-        <h1 className="text-3xl lg:text-4xl xl:text-5xl font-black tracking-[-0.03em] text-white leading-[1.15]">
-          행사 네트워킹을<br />
-          더 쉽고 재밌게
-        </h1>
-        <p className="text-base lg:text-lg text-slate-200 leading-7 max-w-md">
-          행사 목적에 맞는 키워드로 참가자 대화를 유도하고,
-          운영자는 결과와 참여 현황을 한 화면에서 관리합니다.
-        </p>
-        <a
-          href="/demo/play"
-          className="inline-flex items-center gap-2 rounded-xl bg-brand-600 hover:bg-brand-700 active:scale-[0.97] text-white px-6 py-3 text-sm font-bold transition-all"
-        >
-          데모 체험하기 <span aria-hidden="true">&rarr;</span>
-        </a>
+  return (
+    <section ref={heroRef} className="relative border-b border-slate-100 overflow-hidden">
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: "url('/images/hero-networking.jpg')" }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute inset-0 bg-gradient-to-r from-slate-900/85 via-slate-900/70 to-slate-900/30"
+        aria-hidden="true"
+      />
+
+      <div className="relative mx-auto grid max-w-7xl items-start gap-12 px-6 py-16 lg:grid-cols-[1.1fr_0.9fr] lg:px-10 lg:py-20">
+        {/* Left — headline + CTA */}
+        <div className="animate-soft-rise space-y-6">
+          <h1 className="text-3xl lg:text-4xl xl:text-5xl font-black tracking-[-0.03em] text-white leading-[1.15]">
+            행사 네트워킹을<br />
+            더 쉽고 재밌게
+          </h1>
+          <p className="text-base lg:text-lg text-slate-200 leading-7 max-w-md">
+            행사 목적에 맞는 키워드로 참가자 대화를 유도하고,
+            운영자는 결과와 참여 현황을 한 화면에서 관리합니다.
+          </p>
+          <a
+            href="/demo/play"
+            onClick={() =>
+              track("homepage_cta_clicked", {
+                cta_id: "hero_demo_play",
+                cta_destination: "/demo/play",
+                section_id: "hero",
+              })
+            }
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 hover:bg-brand-700 active:scale-[0.97] text-white px-6 py-3 text-sm font-bold transition-all"
+          >
+            데모 체험하기 <span aria-hidden="true">&rarr;</span>
+          </a>
+        </div>
+
+        {/* Right — application form */}
+        <div className="animate-soft-rise" style={{ animationDelay: "90ms" }}>
+          <AdminApplicationForm />
+        </div>
       </div>
-
-      {/* Right — application form */}
-      <div className="animate-soft-rise" style={{ animationDelay: "90ms" }}>
-        <AdminApplicationForm />
-      </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default HeroSection;

--- a/frontend/src/modules/Landing/siteAnalytics.test.ts
+++ b/frontend/src/modules/Landing/siteAnalytics.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSiteAnalyticsPayload,
+  getAnalyticsEnvironment,
+  getReferrerType,
+  getViewportContext,
+} from "./siteAnalytics";
+
+describe("siteAnalytics", () => {
+  it("maps production and private hostnames to separated analytics environments", () => {
+    expect(getAnalyticsEnvironment("bingo.pseudolab-devfactory.com")).toMatchObject({
+      environment: "production",
+      deployment_channel: "bingo",
+      is_production_domain: true,
+    });
+    expect(getAnalyticsEnvironment("bingo-private.pseudolab-devfactory.com")).toMatchObject({
+      environment: "private_dev",
+      deployment_channel: "bingo-private",
+      is_production_domain: false,
+    });
+  });
+
+  it("buckets viewport width without storing raw user agent data", () => {
+    expect(getViewportContext(390)).toEqual({
+      viewport_bucket: "mobile",
+      device_class: "mobile",
+    });
+    expect(getViewportContext(1440)).toEqual({
+      viewport_bucket: "desktop-md",
+      device_class: "desktop",
+    });
+  });
+
+  it("classifies referrers by hostname only", () => {
+    expect(getReferrerType("", "bingo.pseudolab-devfactory.com")).toBe("direct");
+    expect(
+      getReferrerType(
+        "https://bingo.pseudolab-devfactory.com/demo/play",
+        "bingo.pseudolab-devfactory.com"
+      )
+    ).toBe("internal");
+    expect(getReferrerType("https://example.com/path", "bingo.pseudolab-devfactory.com")).toBe(
+      "external"
+    );
+  });
+
+  it("builds a versioned payload with safe core fields", () => {
+    const payload = createSiteAnalyticsPayload({
+      eventName: "demo_start_clicked",
+      properties: { selected_count: 3 },
+      route: "/demo/play",
+      pageViewId: "page-1",
+      analyticsSessionId: "session-1",
+      now: new Date("2026-05-18T00:00:00.000Z"),
+      locationHostname: "bingo.pseudolab-devfactory.com",
+      referrer: "",
+      viewportWidth: 1728,
+    });
+
+    expect(payload).toMatchObject({
+      schema_version: 1,
+      event_name: "demo_start_clicked",
+      event_source: "frontend",
+      analytics_session_id: "session-1",
+      page_view_id: "page-1",
+      occurred_at: "2026-05-18T00:00:00.000Z",
+      route: "/demo/play",
+      hostname: "bingo.pseudolab-devfactory.com",
+      environment: "production",
+      deployment_channel: "bingo",
+      is_production_domain: true,
+      viewport_bucket: "desktop-lg",
+      device_class: "desktop",
+      referrer_type: "direct",
+      properties: { selected_count: 3 },
+      experiments: [],
+    });
+    expect(payload.event_id).toBeTruthy();
+  });
+});

--- a/frontend/src/modules/Landing/siteAnalytics.ts
+++ b/frontend/src/modules/Landing/siteAnalytics.ts
@@ -1,0 +1,423 @@
+import {
+  createContext,
+  createElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { getApiBaseUrl } from "../../lib/apiBase";
+
+export type SiteAnalyticsEventName =
+  | "homepage_viewed"
+  | "homepage_section_viewed"
+  | "homepage_cta_clicked"
+  | "admin_login_clicked"
+  | "application_form_viewed"
+  | "application_form_started"
+  | "application_validation_failed"
+  | "application_submit_clicked"
+  | "application_submitted"
+  | "demo_keyword_selection_viewed"
+  | "demo_keyword_selection_ready"
+  | "demo_start_clicked"
+  | "demo_game_viewed"
+  | "demo_exchange_advanced"
+  | "demo_goal_completed"
+  | "demo_replay_clicked"
+  | "demo_invalid_game_entry_redirected"
+  | "site_route_changed"
+  | "site_session_checkpoint";
+
+export type SiteAnalyticsPropertyValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | string[]
+  | number[];
+
+export type SiteAnalyticsProperties = Record<string, SiteAnalyticsPropertyValue>;
+
+export type SiteAnalyticsPayload = {
+  event_id: string;
+  schema_version: 1;
+  event_name: SiteAnalyticsEventName;
+  event_source: "frontend";
+  analytics_session_id: string;
+  page_view_id: string;
+  occurred_at: string;
+  app_version?: string;
+  route: string;
+  hostname: string;
+  environment: "production" | "private_dev" | "local" | "unknown";
+  deployment_channel: "bingo" | "bingo-private" | "localhost" | "other";
+  is_production_domain: boolean;
+  viewport_bucket: "mobile" | "tablet" | "desktop-sm" | "desktop-md" | "desktop-lg";
+  device_class: "mobile" | "tablet" | "desktop";
+  referrer_type: "direct" | "internal" | "external" | "unknown";
+  properties: SiteAnalyticsProperties;
+  experiments: [];
+};
+
+type SiteAnalyticsContextValue = {
+  route: string;
+  pageViewId: string;
+  track: (
+    eventName: SiteAnalyticsEventName,
+    properties?: SiteAnalyticsProperties,
+    options?: { beacon?: boolean }
+  ) => void;
+};
+
+const ANALYTICS_ENDPOINT = "/api/analytics/events";
+const ANALYTICS_SESSION_KEY = "bingo_site_analytics_session_id";
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
+const DEFAULT_CONTEXT: SiteAnalyticsContextValue = {
+  route: "",
+  pageViewId: "",
+  track: () => undefined,
+};
+
+const SiteAnalyticsContext = createContext<SiteAnalyticsContextValue>(DEFAULT_CONTEXT);
+
+export const createAnalyticsId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `analytics-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const getSessionStorage = () => {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+export const getAnalyticsSessionId = () => {
+  const storage = getSessionStorage();
+  const existingSessionId = storage?.getItem(ANALYTICS_SESSION_KEY);
+  if (existingSessionId) {
+    return existingSessionId;
+  }
+
+  const nextSessionId = createAnalyticsId();
+  storage?.setItem(ANALYTICS_SESSION_KEY, nextSessionId);
+  return nextSessionId;
+};
+
+export const getAnalyticsEnvironment = (hostname: string) => {
+  const normalizedHostname = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "");
+
+  if (normalizedHostname === "bingo.pseudolab-devfactory.com") {
+    return {
+      hostname: normalizedHostname,
+      environment: "production" as const,
+      deployment_channel: "bingo" as const,
+      is_production_domain: true,
+    };
+  }
+
+  if (normalizedHostname === "bingo-private.pseudolab-devfactory.com") {
+    return {
+      hostname: normalizedHostname,
+      environment: "private_dev" as const,
+      deployment_channel: "bingo-private" as const,
+      is_production_domain: false,
+    };
+  }
+
+  if (LOCAL_HOSTS.has(normalizedHostname)) {
+    return {
+      hostname: normalizedHostname,
+      environment: "local" as const,
+      deployment_channel: "localhost" as const,
+      is_production_domain: false,
+    };
+  }
+
+  return {
+    hostname: normalizedHostname,
+    environment: "unknown" as const,
+    deployment_channel: "other" as const,
+    is_production_domain: false,
+  };
+};
+
+export const getViewportContext = (width: number) => {
+  if (width < 640) {
+    return { viewport_bucket: "mobile" as const, device_class: "mobile" as const };
+  }
+  if (width < 1024) {
+    return { viewport_bucket: "tablet" as const, device_class: "tablet" as const };
+  }
+  if (width < 1280) {
+    return { viewport_bucket: "desktop-sm" as const, device_class: "desktop" as const };
+  }
+  if (width < 1600) {
+    return { viewport_bucket: "desktop-md" as const, device_class: "desktop" as const };
+  }
+  return { viewport_bucket: "desktop-lg" as const, device_class: "desktop" as const };
+};
+
+export const getReferrerType = (referrer: string, hostname: string) => {
+  if (!referrer) {
+    return "direct" as const;
+  }
+
+  try {
+    const referrerHostname = new URL(referrer).hostname;
+    return referrerHostname === hostname ? ("internal" as const) : ("external" as const);
+  } catch {
+    return "unknown" as const;
+  }
+};
+
+export const createSiteAnalyticsPayload = ({
+  eventName,
+  properties = {},
+  route,
+  pageViewId,
+  analyticsSessionId,
+  now = new Date(),
+  locationHostname,
+  referrer,
+  viewportWidth,
+}: {
+  eventName: SiteAnalyticsEventName;
+  properties?: SiteAnalyticsProperties;
+  route: string;
+  pageViewId: string;
+  analyticsSessionId: string;
+  now?: Date;
+  locationHostname: string;
+  referrer: string;
+  viewportWidth: number;
+}): SiteAnalyticsPayload => {
+  const environment = getAnalyticsEnvironment(locationHostname);
+  const viewport = getViewportContext(viewportWidth);
+
+  return {
+    event_id: createAnalyticsId(),
+    schema_version: 1,
+    event_name: eventName,
+    event_source: "frontend",
+    analytics_session_id: analyticsSessionId,
+    page_view_id: pageViewId,
+    occurred_at: now.toISOString(),
+    app_version: import.meta.env.VITE_APP_VERSION || import.meta.env.VITE_GIT_SHA || undefined,
+    route,
+    hostname: environment.hostname,
+    environment: environment.environment,
+    deployment_channel: environment.deployment_channel,
+    is_production_domain: environment.is_production_domain,
+    viewport_bucket: viewport.viewport_bucket,
+    device_class: viewport.device_class,
+    referrer_type: getReferrerType(referrer, environment.hostname),
+    properties,
+    experiments: [],
+  };
+};
+
+const shouldSendToCollector = (hostname: string) => {
+  const { environment } = getAnalyticsEnvironment(hostname);
+  return environment === "production" || environment === "private_dev";
+};
+
+const getAnalyticsEndpointUrl = () => {
+  const baseUrl = getApiBaseUrl();
+  return new URL(ANALYTICS_ENDPOINT, baseUrl).toString();
+};
+
+const sendAnalyticsPayload = (payload: SiteAnalyticsPayload, beacon = false) => {
+  if (import.meta.env.DEV) {
+    // Visible in private/local development without sending personal form values.
+    console.debug("[site-analytics]", payload.event_name, payload.properties);
+  }
+
+  if (typeof window === "undefined" || !shouldSendToCollector(window.location.hostname)) {
+    return;
+  }
+
+  const body = JSON.stringify(payload);
+  if (beacon && "sendBeacon" in navigator) {
+    const sent = navigator.sendBeacon(
+      getAnalyticsEndpointUrl(),
+      new Blob([body], { type: "application/json" })
+    );
+    if (sent) {
+      return;
+    }
+  }
+
+  void fetch(getAnalyticsEndpointUrl(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive: beacon,
+  }).catch(() => {
+    // Analytics transport must never block product behavior.
+  });
+};
+
+const getMaxScrollPercent = () => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return 0;
+  }
+
+  const scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
+  const scrollableHeight = Math.max(
+    1,
+    document.documentElement.scrollHeight - window.innerHeight
+  );
+  return Math.min(100, Math.round((scrollTop / scrollableHeight) * 100));
+};
+
+export const SiteAnalyticsScope = ({
+  route,
+  pageEventName,
+  pageProperties = {},
+  children,
+}: {
+  route: string;
+  pageEventName: SiteAnalyticsEventName;
+  pageProperties?: SiteAnalyticsProperties;
+  children: ReactNode;
+}) => {
+  const pageViewRef = useRef({ route, pageViewId: createAnalyticsId() });
+  if (pageViewRef.current.route !== route) {
+    pageViewRef.current = { route, pageViewId: createAnalyticsId() };
+  }
+  const pageViewId = pageViewRef.current.pageViewId;
+  const analyticsSessionId = useMemo(() => getAnalyticsSessionId(), []);
+  const startedAtRef = useRef(Date.now());
+  const maxScrollPercentRef = useRef(0);
+  const lastEventNameRef = useRef<SiteAnalyticsEventName>(pageEventName);
+
+  const track = (
+    eventName: SiteAnalyticsEventName,
+    properties: SiteAnalyticsProperties = {},
+    options: { beacon?: boolean } = {}
+  ) => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    lastEventNameRef.current = eventName;
+    sendAnalyticsPayload(
+      createSiteAnalyticsPayload({
+        eventName,
+        properties,
+        route,
+        pageViewId,
+        analyticsSessionId,
+        locationHostname: window.location.hostname,
+        referrer: document.referrer,
+        viewportWidth: window.innerWidth,
+      }),
+      options.beacon
+    );
+  };
+
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    maxScrollPercentRef.current = getMaxScrollPercent();
+    track(pageEventName, pageProperties);
+
+    const updateScrollDepth = () => {
+      maxScrollPercentRef.current = Math.max(maxScrollPercentRef.current, getMaxScrollPercent());
+    };
+    const sendCheckpoint = () => {
+      track(
+        "site_session_checkpoint",
+        {
+          route,
+          active_duration_ms: Date.now() - startedAtRef.current,
+          max_scroll_percent: maxScrollPercentRef.current,
+          last_event_name: lastEventNameRef.current,
+          engaged: Date.now() - startedAtRef.current >= 10_000 || maxScrollPercentRef.current >= 25,
+        },
+        { beacon: true }
+      );
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        sendCheckpoint();
+      }
+    };
+
+    window.addEventListener("scroll", updateScrollDepth, { passive: true });
+    window.addEventListener("pagehide", sendCheckpoint);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("scroll", updateScrollDepth);
+      window.removeEventListener("pagehide", sendCheckpoint);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      track(
+        "site_route_changed",
+        {
+          from_route: route,
+          to_route: window.location.pathname,
+          duration_ms_on_from_route: Date.now() - startedAtRef.current,
+          max_scroll_percent_on_from_route: maxScrollPercentRef.current,
+          last_event_name: lastEventNameRef.current,
+          engaged: Date.now() - startedAtRef.current >= 10_000 || maxScrollPercentRef.current >= 25,
+        },
+        { beacon: true }
+      );
+    };
+    // pageProperties is intentionally captured on route entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [route, pageEventName, pageViewId, analyticsSessionId]);
+
+  return createElement(
+    SiteAnalyticsContext.Provider,
+    { value: { route, pageViewId, track } },
+    children
+  );
+};
+
+export const useSiteAnalytics = () => useContext(SiteAnalyticsContext);
+
+export const useSiteSectionExposure = <T extends HTMLElement>(
+  sectionId: string,
+  sectionIndex: number
+): RefObject<T> => {
+  const elementRef = useRef<T | null>(null);
+  const { track } = useSiteAnalytics();
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element || hasTrackedRef.current || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && entry.intersectionRatio >= 0.35 && !hasTrackedRef.current) {
+          hasTrackedRef.current = true;
+          track("homepage_section_viewed", {
+            section_id: sectionId,
+            section_index: sectionIndex,
+            viewport_percent_visible: Math.round(entry.intersectionRatio * 100),
+          });
+          observer.disconnect();
+        }
+      },
+      { threshold: [0.35, 0.6] }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [sectionId, sectionIndex, track]);
+
+  return elementRef as RefObject<T>;
+};


### PR DESCRIPTION
## 요약
- 홈페이지와 데모 페이지의 analytics 이벤트를 생성하는 FE 계측 어댑터를 추가했습니다.
- 운영/개발 도메인 분리를 위해 hostname, environment, deployment_channel, production domain 여부를 payload와 backend validation에 포함했습니다.
- 이름, 이메일, free-text, raw query, raw user-agent, IP성 필드를 analytics properties에서 거부하는 수집 API를 추가했습니다.
- `site_analytics_events` 테이블과 Alembic migration을 추가하고 `event_id` dedupe를 적용했습니다.

## 검증
- `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests/test_analytics_routes.py -q`
- `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests -q`
- `npm test -- siteAnalytics.test.ts`
- `npm run lint`
- `npm run build`
- `npm run e2e -- landing-page.spec.ts public-entrypoints.smoke.spec.ts`

## 이슈
- 닫을 이슈 없음.
- 대시보드/실험 플랫폼/A-B 테스트 로직은 후속 작업으로 분리합니다.

## 주의
- FE transport는 `bingo.pseudolab-devfactory.com`, `bingo-private.pseudolab-devfactory.com`에서만 backend collector로 전송하고, local에서는 console debug만 수행합니다.
- 운영 분석 시 `environment = 'production'` 및 `hostname = 'bingo.pseudolab-devfactory.com'` 필터를 사용해야 합니다.