### PR TITLE
fix: 데모 버튼 스타일 우선순위 고정

### DIFF
--- a/frontend/e2e/public-entrypoints.smoke.spec.ts
+++ b/frontend/e2e/public-entrypoints.smoke.spec.ts
@@ -19,11 +19,22 @@ test("demo experience starts without login and records a sample encounter", asyn
   await expect(page.getByText("키워드를 보내면 기록이 여기에 쌓입니다.")).toBeVisible();
   await expect(page.getByText("받은 키워드가 생기면 기록이 표시됩니다.")).toBeVisible();
 
-  await page.getByRole("button", { name: "보내기" }).click();
+  const sendButton = page.getByRole("button", { name: "보내기" });
+  await expect(sendButton).toHaveCSS("background-color", "rgb(79, 195, 153)");
+
+  await sendButton.click();
+  await page.mouse.move(0, 0);
   await expect(page.getByText("내 키워드를 보냈어요")).toBeVisible();
   await expect(page.getByText("김철수 님").first()).toBeVisible();
 
-  await page.getByRole("button", { name: "키워드 받기" }).click();
+  const receiveButton = page.getByRole("button", { name: "키워드 받기" });
+  await expect(receiveButton).toHaveCSS("background-color", "rgb(221, 255, 87)");
+  await expect(page.getByRole("button", { name: "다시 체험하기" })).toHaveCSS(
+    "background-color",
+    "rgb(221, 255, 87)",
+  );
+
+  await receiveButton.click();
   await expect(page.getByText("김민수 님에게")).toBeVisible();
   await expect(page.getByText("키워드를 받았어요")).toBeVisible();
 });

--- a/frontend/src/modules/Landing/DemoPlayPage.tsx
+++ b/frontend/src/modules/Landing/DemoPlayPage.tsx
@@ -217,7 +217,7 @@ const KeywordSelector = ({
 
       <Button
         type="button"
-        className="mt-[31px] h-[65px] w-[600px] rounded-[32.5px] bg-[#4fc399] text-[22px] font-black tracking-[-0.04em] hover:bg-[#28d791] disabled:bg-[#a7c4c8] disabled:opacity-100"
+        className="mt-[31px] h-[65px] w-[600px] rounded-[32.5px] !bg-[#4fc399] text-[22px] font-black tracking-[-0.04em] !text-white hover:!bg-[#28d791] disabled:!bg-[#a7c4c8] disabled:!opacity-100"
         disabled={!canStart}
         onClick={onStart}
       >
@@ -692,7 +692,7 @@ const DemoPlayPage = () => {
                     </div>
                     <Button
                       type="button"
-                      className="h-[52px] w-[118px] rounded-[26px] bg-[#ddff57] text-[17px] font-black tracking-[-0.04em] text-[#076945] hover:bg-[#e8ff86] disabled:bg-[#a7c4c8] disabled:opacity-100"
+                      className="h-[52px] w-[118px] rounded-[26px] !bg-[#ddff57] text-[17px] font-black tracking-[-0.04em] !text-[#076945] hover:!bg-[#e8ff86] disabled:!bg-[#a7c4c8] disabled:!opacity-100"
                       disabled={isComplete}
                       onClick={handleNext}
                     >
@@ -706,7 +706,7 @@ const DemoPlayPage = () => {
                     </p>
                     <Button
                       type="button"
-                      className="h-[52px] w-[118px] rounded-[26px] bg-[#4fc399] text-[19px] font-black tracking-[-0.04em] hover:bg-[#28d791] disabled:bg-[#a7c4c8] disabled:opacity-100"
+                      className="h-[52px] w-[118px] rounded-[26px] !bg-[#4fc399] text-[19px] font-black tracking-[-0.04em] !text-white hover:!bg-[#28d791] disabled:!bg-[#a7c4c8] disabled:!opacity-100"
                       disabled={isComplete}
                       onClick={handleNext}
                     >
@@ -724,7 +724,7 @@ const DemoPlayPage = () => {
                   <Button
                     type="button"
                     variant="ghost"
-                    className="absolute right-[23px] top-[24px] h-[42px] rounded-full border border-[#076945]/20 bg-[#ddff57] px-[18px] text-[17px] font-black tracking-[-0.04em] text-[#076945] shadow-[0_8px_18px_rgba(7,105,69,0.18)] hover:bg-[#e8ff86] hover:text-[#076945]"
+                    className="absolute right-[23px] top-[24px] h-[42px] rounded-full border border-[#076945]/20 !bg-[#ddff57] px-[18px] text-[17px] font-black tracking-[-0.04em] !text-[#076945] shadow-[0_8px_18px_rgba(7,105,69,0.18)] hover:!bg-[#e8ff86] hover:!text-[#076945]"
                     onClick={handleReplay}
                   >
                     다시 체험하기


### PR DESCRIPTION
## 변경 사항
- 데모 플레이 화면의 커스텀 버튼 배경/텍스트 색상에 Tailwind important modifier를 적용했습니다.
- dev 서버와 production build에서 `Button` 기본 variant 클래스가 서로 다르게 우선 적용되는 문제를 방지했습니다.
- 데모 smoke e2e에 `보내기`, `키워드 받기`, `다시 체험하기` 버튼 배경색 검증을 추가했습니다.

## 검증
- `npm run build`
- `npx playwright test e2e/public-entrypoints.smoke.spec.ts`
- production preview에서 computed style 확인: `보내기` `rgb(79, 195, 153)`, `키워드 받기`/`다시 체험하기` `rgb(221, 255, 87)`

## 영향 범위
- FE 데모 플레이 화면 버튼 스타일만 변경했습니다.