### PR TITLE
ci: Alembic 단일 head 검사 추가

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest
 
+      - name: Check Alembic has a single head
+        run: |
+          set -euo pipefail
+
+          heads="$(alembic heads)"
+          echo "$heads"
+
+          head_count="$(printf '%s\n' "$heads" | sed '/^$/d' | wc -l | tr -d ' ')"
+          if [ "$head_count" != "1" ]; then
+            echo "::error::Expected exactly one Alembic head, found $head_count."
+            echo "::error::If multiple independent migration heads are intentional, add an explicit merge revision."
+            exit 1
+          fi
+
       - name: Unit tests
         env:
           PYTHONPATH: app


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: 운영 migrate 컨테이너 Alembic multiple heads 재발 방지

## Impact Trigger (Select At Least One)
- [ ] Cross-domain change (BE/FE/Infra)
- [ ] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [x] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [ ] BE (`backend/**`)
- [ ] FE (`frontend/**`)
- [x] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [ ] docs/reference/agent-collaboration.md

## Changes
- Backend CI job에 `alembic heads` 단일 head 검사를 추가했습니다.
- Alembic head가 0개 또는 2개 이상이면 CI가 실패하고 merge revision 추가 안내를 출력합니다.
- 운영 장애 원인이었던 migration head 분기를 PR 단계에서 차단합니다.

## Validation
- Tests:
  - `cd backend && alembic heads`
  - CI step과 동일한 shell snippet 로컬 실행
  - `git diff --check`
- Result:
  - `8f4b2d9c1a30 (head)` 1개 확인
  - `head_count=1` 확인
  - whitespace check 통과
- Not run and reason:
  - `actionlint`: 현재 작업 환경에 설치되어 있지 않아 미실행

## Guide Sync Check
- [ ] Updated Korean mirrors for changed English guides
- 문서 변경 없음

## Handoff
- [ ] Added handoff note following docs/templates/agent-handoff.md
- 단일 CI step 추가라 별도 handoff 문서는 생략했습니다.
