### PR TITLE
모바일 데모 준비 중 안내 표시

### DIFF
--- a/frontend/e2e/public-entrypoints.smoke.spec.ts
+++ b/frontend/e2e/public-entrypoints.smoke.spec.ts
@@ -1,12 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
-
-const readLatestCollectedKeywordCount = async (page: Page) =>
-  page.evaluate(() => {
-    const matches = Array.from(
-      document.body.innerText.matchAll(/수집한 키워드\n(\d+)\/24/g),
-    );
-    return Number(matches.at(-1)?.[1] ?? -1);
-  });
+import { expect, test } from "@playwright/test";
 
 test("demo experience starts without login and records a sample encounter", async ({
   page,
@@ -84,107 +76,20 @@ test("demo experience starts without login and records a sample encounter", asyn
   await expect(page.getByText("키워드를 받았어요")).toBeVisible();
 });
 
-test("mobile demo tutorial gates send and fills board after scroll", async ({
+test("mobile demo is blocked with preparation notice", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/demo/play");
 
-  await page.getByRole("button", { name: "AI", exact: true }).click();
-  await page.getByRole("button", { name: "디자인", exact: true }).click();
-  await page.getByRole("button", { name: "프로덕트", exact: true }).click();
-  await page.getByRole("button", { name: "빙고 시작하기" }).click();
+  await expect(page.getByRole("heading", { name: /모바일 데모는/ })).toBeVisible();
+  await expect(page.getByText("PC에서 데모를 체험해 주세요.")).toBeVisible();
+  await expect(page.getByRole("link", { name: "홈으로 돌아가기" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "빙고 시작하기" })).toHaveCount(0);
 
-  await expect(page).toHaveURL(/\/demo\/play\/game\?keywords=/);
-  await expect(
-    page.getByText("참가자 이름을 검색한 뒤 내 키워드를 보내보세요."),
-  ).toBeVisible();
-
-  const nameLabel = page.locator(".bingo-hero__form-field span").first();
-  const nameChoice = page.getByRole("button", { name: /김철수/ });
-  const sendButton = page.getByRole("button", { name: "보내기" });
-
-  await expect(nameLabel).toHaveCSS("color", "rgb(203, 213, 225)");
-  await expect(sendButton).toBeDisabled();
-  await expect
-    .poll(async () =>
-      page.evaluate(() => {
-        const form = document.querySelector(".bingo-hero__form");
-        const button = form?.querySelector("button");
-        const formBox = form?.getBoundingClientRect();
-        const buttonBox = button?.getBoundingClientRect();
-
-        if (!formBox || !buttonBox) {
-          return false;
-        }
-
-        return (
-          buttonBox.left >= formBox.left + 8 &&
-          buttonBox.right <= formBox.right - 8 &&
-          buttonBox.top >= formBox.top + 4 &&
-          buttonBox.bottom <= formBox.bottom - 4
-        );
-      }),
-    )
-    .toBe(true);
-
-  await page.mouse.wheel(0, 500);
-  await page.waitForTimeout(100);
-  expect(await page.evaluate(() => window.scrollY)).toBe(0);
-
-  await nameChoice.click();
-  await expect(nameLabel).toHaveCSS("color", "rgb(7, 19, 34)");
-  await expect(sendButton).toBeEnabled();
-
-  await sendButton.click();
-  const receiveButton = page.getByRole("button", { name: "키워드 수신 테스트" });
-  await expect(receiveButton).toBeVisible();
-  await expect(
-    page.getByText("상대방이 키워드를 보내면 내 빙고판에 상대방의 키워드가 채워집니다."),
-  ).toBeVisible();
-
-  await expect.poll(() => readLatestCollectedKeywordCount(page)).toBe(0);
-  await receiveButton.click();
-  await page.waitForTimeout(180);
-  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
-  expect(await readLatestCollectedKeywordCount(page)).toBe(0);
-  await expect
-    .poll(() => readLatestCollectedKeywordCount(page), { timeout: 2000 })
-    .toBeGreaterThan(0);
-  await expect(page.locator('[data-demo-board-highlighted="true"]')).toBeVisible();
-  await expect(
-    page.getByText("빙고판을 보며 다음 키워드 교환을 이어가요."),
-  ).toBeVisible();
-  await expect(page.getByRole("button", { name: "키워드 수신 테스트" })).toHaveCount(1);
-
-  for (let stepIndex = 0; stepIndex < 10; stepIndex += 1) {
-    if (await page.getByRole("button", { name: "다시 체험하기" }).isVisible()) {
-      break;
-    }
-
-    const nextSendButton = page.getByRole("button", { name: "보내기" }).last();
-    if ((await nextSendButton.count()) > 0 && !(await nextSendButton.isDisabled())) {
-      await nextSendButton.click();
-    } else if ((await nextSendButton.count()) > 0) {
-      await page.locator('[role="button"]').last().click();
-    } else {
-      await page.getByRole("button", { name: "키워드 수신 테스트" }).last().click();
-    }
-
-    await page.waitForTimeout(700);
-  }
-
-  await expect(page.getByText("참가자 이름 검색")).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "완료" })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "다시 체험하기" })).toHaveCount(1);
-  await expect(page.locator('[class*="backdrop-blur-[2px]"]')).toHaveCount(0);
-  await page.getByRole("button", { name: "다시 체험하기" }).click();
-  await expect(
-    page.getByText("참가자 이름을 검색한 뒤 내 키워드를 보내보세요."),
-  ).toBeHidden();
-  await expect(page.locator('[class*="backdrop-blur-[3px]"]')).toHaveCount(0);
-  await expect(page.locator('[class*="ring-[5px]"]')).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "보내기" })).toBeDisabled();
+  await page.goto("/demo/play/game?keywords=AI,%EB%94%94%EC%9E%90%EC%9D%B8,%ED%94%84%EB%A1%9C%EB%8D%95%ED%8A%B8");
+  await expect(page.getByRole("heading", { name: /모바일 데모는/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: "보내기" })).toHaveCount(0);
 });
 
 test("admin login entrypoint renders Google login guidance", async ({

--- a/frontend/src/modules/Landing/DemoPlayPage.tsx
+++ b/frontend/src/modules/Landing/DemoPlayPage.tsx
@@ -322,6 +322,39 @@ const MobileKeywordSelector = ({
   </main>
 );
 
+const MobileDemoUnavailable = () => (
+  <main className="fixed inset-0 flex overflow-hidden bg-[#4fc39b] px-5 pb-6 pt-5 text-slate-950">
+    <div className="flex h-full w-full flex-col">
+      <header className="flex items-center justify-between gap-3">
+        <Link to="/" aria-label="Bingo Networking 홈으로 이동" className="block">
+          <img src={bingoNetworkingWordmark} alt="Bingo Networking" className="h-auto w-[148px]" />
+        </Link>
+        <DemoBadgeLink className="h-[30px] px-3 text-[12px]" />
+      </header>
+
+      <section className="flex flex-1 items-center">
+        <div className="w-full rounded-[28px] bg-white px-6 py-8 text-center shadow-soft">
+          <p className="text-[34px] leading-none text-[#9cee69]">✦</p>
+          <h1 className="mt-3 text-[32px] font-black leading-[38px] tracking-[-0.07em] text-[#076945]">
+            모바일 데모는
+            <br />
+            준비 중입니다
+          </h1>
+          <p className="mx-auto mt-5 max-w-[280px] text-[16px] font-black leading-[24px] tracking-[-0.04em] text-[#076945]/72">
+            PC에서 데모를 체험해 주세요.
+          </p>
+          <Link
+            to="/"
+            className="mt-7 inline-flex h-[48px] items-center justify-center rounded-[24px] bg-[#076945] px-7 text-[16px] font-black tracking-[-0.04em] text-white transition hover:bg-[#00905b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ddff57]"
+          >
+            홈으로 돌아가기
+          </Link>
+        </div>
+      </section>
+    </div>
+  </main>
+);
+
 const ExchangeCard = ({
   step,
   index,
@@ -1393,22 +1426,15 @@ const DemoPlayPageContent = ({ demoRunId }: { demoRunId: string }) => {
   const isInvalidGameEntry =
     isGameRoute && selectedKeywordsFromQuery.length < DEMO_PLAY_MIN_SELECTED_KEYWORDS;
 
+  if (isMobileViewport) {
+    return <MobileDemoUnavailable />;
+  }
+
   if (isInvalidGameEntry) {
     return <Navigate to="/demo/play" replace />;
   }
 
   if (!isGameRoute) {
-    if (isMobileViewport) {
-      return (
-        <MobileKeywordSelector
-          selectedKeywords={draftKeywords}
-          onToggleKeyword={handleToggleKeyword}
-          canStart={canStart}
-          onStart={handleStart}
-        />
-      );
-    }
-
     return (
       <PcDesignStage>
         <main className="relative h-[1080px] w-[1920px] bg-[#4fc39b]">


### PR DESCRIPTION
## 요약
- 모바일 `/demo/play`과 `/demo/play/game`에서 데모 UI 대신 준비 중 안내를 표시합니다.
- PC 데모 플로우와 실제 이벤트 빙고 라우트는 유지합니다.
- 모바일 smoke 테스트를 데모 차단 안내 확인 기준으로 갱신했습니다.

## 검증
- `node node_modules/typescript/bin/tsc && node node_modules/vite/bin/vite.js build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:4175 node node_modules/@playwright/test/cli.js test e2e/public-entrypoints.smoke.spec.ts --reporter=line --grep "demo|mobile demo"`