### PR TITLE
데모 안내 스킵 상태를 세션에 저장하지 않기

### DIFF
--- a/frontend/src/modules/Landing/DemoPlayPage.tsx
+++ b/frontend/src/modules/Landing/DemoPlayPage.tsx
@@ -34,7 +34,6 @@ const PC_GAME_CANVAS_HEIGHT = 1080;
 const DEMO_RECEIVE_ALERT_DURATION_MS = 1300;
 const DEMO_GOAL_OVERLAY_DURATION_MS = 2000;
 const DEMO_BOARD_HIGHLIGHT_DURATION_MS = 1700;
-const DEMO_SKIP_GUIDANCE_STORAGE_KEY = "bingo-demo-play-skip-guidance";
 
 type DemoGuidanceMode = "send" | "receive";
 
@@ -1044,11 +1043,7 @@ const DemoPlayPageContent = ({ demoRunId }: { demoRunId: string }) => {
   const [draftKeywords, setDraftKeywords] = useState<string[]>([]);
   const [completedStepCount, setCompletedStepCount] = useState(0);
   const [isDemoParticipantSelected, setIsDemoParticipantSelected] = useState(false);
-  const [shouldSkipGuidance, setShouldSkipGuidance] = useState(
-    () =>
-      typeof window !== "undefined" &&
-      window.sessionStorage.getItem(DEMO_SKIP_GUIDANCE_STORAGE_KEY) === "true"
-  );
+  const [shouldSkipGuidance, setShouldSkipGuidance] = useState(false);
   const alertTimeoutRef = useRef<number | null>(null);
   const [sendAlert, setSendAlert] = useState({
     open: false,
@@ -1232,7 +1227,6 @@ const DemoPlayPageContent = ({ demoRunId }: { demoRunId: string }) => {
     if (!canStart) {
       return;
     }
-    window.sessionStorage.removeItem(DEMO_SKIP_GUIDANCE_STORAGE_KEY);
     setShouldSkipGuidance(false);
     track("demo_start_clicked", {
       selected_count: draftKeywords.length,
@@ -1354,7 +1348,6 @@ const DemoPlayPageContent = ({ demoRunId }: { demoRunId: string }) => {
       },
       { beacon: true }
     );
-    window.sessionStorage.setItem(DEMO_SKIP_GUIDANCE_STORAGE_KEY, "true");
     setShouldSkipGuidance(true);
     setCompletedStepCount(0);
     setIsDemoParticipantSelected(false);


### PR DESCRIPTION
## 요약
- 데모 안내 스킵 상태를 `sessionStorage`에 저장하지 않도록 변경했습니다.
- `다시 체험하기` 직후에는 기존처럼 안내를 생략하지만, 새로 진입/새로고침한 데모에서는 하이라이트 안내가 다시 표시됩니다.
- 운영 브라우저에 남은 `bingo-demo-play-skip-guidance` 값 때문에 하이라이트가 계속 생략될 수 있던 문제를 정리했습니다.

## 검증
- `node node_modules/typescript/bin/tsc && node node_modules/vite/bin/vite.js build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:4176 node node_modules/@playwright/test/cli.js test e2e/public-entrypoints.smoke.spec.ts --reporter=line --grep "demo|mobile demo"`

