### PR TITLE
feat(analytics): 홍보 유입 및 QA 트래픽 추적 보강

### DIFF
--- a/backend/app/api/analytics/routes.py
+++ b/backend/app/api/analytics/routes.py
@@ -43,6 +43,20 @@ ALLOWED_EVENT_SOURCES = {"frontend"}
 ALLOWED_DEVICE_CLASSES = {"mobile", "tablet", "desktop"}
 ALLOWED_VIEWPORT_BUCKETS = {"mobile", "tablet", "desktop-sm", "desktop-md", "desktop-lg"}
 ALLOWED_REFERRER_TYPES = {"direct", "internal", "external", "unknown"}
+ALLOWED_TRAFFIC_TYPES = {"public", "internal_qa"}
+ALLOWED_UTM_PROPERTY_KEYS = {"utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"}
+ALLOWED_REFERRER_DOMAIN_BUCKETS = {
+    "direct",
+    "internal",
+    "luma",
+    "google",
+    "linkedin",
+    "facebook",
+    "instagram",
+    "github",
+    "other_external",
+    "unknown",
+}
 HOST_ENVIRONMENT_MAP = {
     "bingo.pseudolab-devfactory.com": ("production", "bingo", True),
     "bingo-private.pseudolab-devfactory.com": ("private_dev", "bingo-private", False),
@@ -53,6 +67,7 @@ HOST_ENVIRONMENT_MAP = {
 }
 LOCAL_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+ANALYTICS_TOKEN_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,79}$")
 DISALLOWED_PROPERTY_KEYS = {
     "email",
     "name",
@@ -77,6 +92,60 @@ DISALLOWED_PROPERTY_KEYS = {
     "purpose",
     "notes",
 }
+
+
+def validate_low_cardinality_token(value: Any, path: str) -> None:
+    if not isinstance(value, str) or not ANALYTICS_TOKEN_PATTERN.fullmatch(value):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"허용되지 않은 analytics property 값입니다: {path}",
+        )
+
+
+def validate_known_property_value(key: str, value: Any, path: str) -> None:
+    if key == "traffic_type":
+        if value not in ALLOWED_TRAFFIC_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"허용되지 않은 traffic_type입니다: {path}",
+            )
+        return
+
+    if key.startswith("utm_"):
+        if key not in ALLOWED_UTM_PROPERTY_KEYS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"허용되지 않은 UTM analytics property입니다: {path}",
+            )
+        validate_low_cardinality_token(value, path)
+        return
+
+    if key in {"session_entry_utm_source", "session_entry_utm_medium", "session_entry_utm_campaign"}:
+        validate_low_cardinality_token(value, path)
+        return
+
+    if key == "referrer_domain_bucket" or key == "session_entry_referrer_domain_bucket":
+        if value not in ALLOWED_REFERRER_DOMAIN_BUCKETS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"허용되지 않은 referrer domain bucket입니다: {path}",
+            )
+        return
+
+    if key == "session_entry_referrer_type":
+        if value not in ALLOWED_REFERRER_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"허용되지 않은 session entry referrer type입니다: {path}",
+            )
+        return
+
+    if key == "session_entry_route":
+        if value not in ALLOWED_ROUTES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"허용되지 않은 session entry route입니다: {path}",
+            )
 
 
 def normalize_hostname(hostname: str) -> str:
@@ -141,6 +210,7 @@ def validate_safe_properties(value: Any, path: str = "properties") -> None:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"개인정보 또는 원문 로그로 판단되는 필드는 저장할 수 없습니다: {path}.{key}",
                 )
+            validate_known_property_value(normalized_key, nested_value, f"{path}.{key}")
             validate_safe_properties(nested_value, f"{path}.{key}")
         return
 

--- a/backend/app/tests/test_analytics_routes.py
+++ b/backend/app/tests/test_analytics_routes.py
@@ -91,6 +91,61 @@ def test_validate_analytics_event_payload_rejects_personal_information_propertie
     assert exc_info.value.status_code == 400
 
 
+def test_validate_analytics_event_payload_accepts_campaign_and_qa_properties():
+    properties = {
+        "entry_path": "/",
+        "traffic_type": "internal_qa",
+        "utm_source": "luma",
+        "utm_medium": "event_page",
+        "utm_campaign": "networking_promo_20260521",
+        "utm_content": "poster_a",
+        "referrer_domain_bucket": "luma",
+        "session_entry_route": "/",
+        "session_entry_referrer_type": "external",
+        "session_entry_referrer_domain_bucket": "luma",
+        "session_entry_utm_source": "luma",
+        "session_entry_utm_medium": "event_page",
+        "session_entry_utm_campaign": "networking_promo_20260521",
+    }
+
+    validated = validate_analytics_event_payload(
+        _request_payload(properties=properties, referrer_type="external"),
+        _request(headers={"origin": "https://bingo.pseudolab-devfactory.com"}),
+    )
+
+    assert validated["properties"] == properties
+
+
+def test_validate_analytics_event_payload_rejects_invalid_traffic_type():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_analytics_event_payload(
+            _request_payload(properties={"traffic_type": "developer"}),
+            _request(),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_analytics_event_payload_rejects_unknown_utm_property():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_analytics_event_payload(
+            _request_payload(properties={"utm_raw_url": "https_example.com"}),
+            _request(),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_analytics_event_payload_rejects_unsafe_campaign_value():
+    with pytest.raises(HTTPException) as exc_info:
+        validate_analytics_event_payload(
+            _request_payload(properties={"utm_campaign": "networking promo 20260521"}),
+            _request(),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
 def test_create_analytics_event_returns_duplicate_without_second_insert(monkeypatch):
     calls = {"create": 0}
 

--- a/frontend/src/modules/Landing/siteAnalytics.test.ts
+++ b/frontend/src/modules/Landing/siteAnalytics.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   createSiteAnalyticsPayload,
   getAnalyticsEnvironment,
+  getCampaignContext,
+  getReferrerDomainBucket,
   getReferrerType,
   getViewportContext,
 } from "./siteAnalytics";
@@ -44,6 +46,42 @@ describe("siteAnalytics", () => {
     );
   });
 
+  it("buckets external referrer domains without storing full referrer paths", () => {
+    expect(getReferrerDomainBucket("", "bingo.pseudolab-devfactory.com")).toBe("direct");
+    expect(
+      getReferrerDomainBucket(
+        "https://bingo.pseudolab-devfactory.com/demo/play",
+        "bingo.pseudolab-devfactory.com"
+      )
+    ).toBe("internal");
+    expect(
+      getReferrerDomainBucket("https://lu.ma/promo-event", "bingo.pseudolab-devfactory.com")
+    ).toBe("luma");
+    expect(
+      getReferrerDomainBucket("https://example.com/path", "bingo.pseudolab-devfactory.com")
+    ).toBe("other_external");
+  });
+
+  it("normalizes UTM fields and QA traffic type from query parameters", () => {
+    expect(
+      getCampaignContext(
+        "?utm_source=Lu.ma&utm_medium=Event Page&utm_campaign=Networking Promo 20260521&utm_content=Poster A&qa=1&raw_url=https://example.com"
+      )
+    ).toEqual({
+      traffic_type: "internal_qa",
+      utm_source: "lu.ma",
+      utm_medium: "event_page",
+      utm_campaign: "networking_promo_20260521",
+      utm_content: "poster_a",
+    });
+    expect(getCampaignContext("?traffic_type=internal_qa")).toEqual({
+      traffic_type: "internal_qa",
+    });
+    expect(getCampaignContext("?traffic_type=unexpected")).toEqual({
+      traffic_type: "public",
+    });
+  });
+
   it("builds a versioned payload with safe core fields", () => {
     const payload = createSiteAnalyticsPayload({
       eventName: "demo_start_clicked",
@@ -54,6 +92,8 @@ describe("siteAnalytics", () => {
       now: new Date("2026-05-18T00:00:00.000Z"),
       locationHostname: "bingo.pseudolab-devfactory.com",
       referrer: "",
+      locationSearch:
+        "?utm_source=luma&utm_medium=event_page&utm_campaign=networking_promo_20260521&traffic_type=internal_qa",
       viewportWidth: 1728,
     });
 
@@ -72,7 +112,20 @@ describe("siteAnalytics", () => {
       viewport_bucket: "desktop-lg",
       device_class: "desktop",
       referrer_type: "direct",
-      properties: { selected_count: 3 },
+      properties: {
+        selected_count: 3,
+        traffic_type: "internal_qa",
+        utm_source: "luma",
+        utm_medium: "event_page",
+        utm_campaign: "networking_promo_20260521",
+        referrer_domain_bucket: "direct",
+        session_entry_route: "/demo/play",
+        session_entry_referrer_type: "direct",
+        session_entry_referrer_domain_bucket: "direct",
+        session_entry_utm_source: "luma",
+        session_entry_utm_medium: "event_page",
+        session_entry_utm_campaign: "networking_promo_20260521",
+      },
       experiments: [],
     });
     expect(payload.event_id).toBeTruthy();

--- a/frontend/src/modules/Landing/siteAnalytics.ts
+++ b/frontend/src/modules/Landing/siteAnalytics.ts
@@ -42,6 +42,38 @@ export type SiteAnalyticsPropertyValue =
 
 export type SiteAnalyticsProperties = Record<string, SiteAnalyticsPropertyValue>;
 
+type AnalyticsTrafficType = "public" | "internal_qa";
+type ReferrerDomainBucket =
+  | "direct"
+  | "internal"
+  | "luma"
+  | "google"
+  | "linkedin"
+  | "facebook"
+  | "instagram"
+  | "github"
+  | "other_external"
+  | "unknown";
+
+type CampaignContext = {
+  traffic_type: AnalyticsTrafficType;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+};
+
+type SessionEntryContext = {
+  traffic_type: AnalyticsTrafficType;
+  session_entry_route: string;
+  session_entry_referrer_type: "direct" | "internal" | "external" | "unknown";
+  session_entry_referrer_domain_bucket: ReferrerDomainBucket;
+  session_entry_utm_source?: string;
+  session_entry_utm_medium?: string;
+  session_entry_utm_campaign?: string;
+};
+
 export type SiteAnalyticsPayload = {
   event_id: string;
   schema_version: 1;
@@ -75,6 +107,8 @@ type SiteAnalyticsContextValue = {
 
 const ANALYTICS_ENDPOINT = "/api/analytics/events";
 const ANALYTICS_SESSION_KEY = "bingo_site_analytics_session_id";
+const ANALYTICS_ENTRY_CONTEXT_KEY = "bingo_site_analytics_entry_context";
+const ANALYTICS_VALUE_MAX_LENGTH = 80;
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
 const DEFAULT_CONTEXT: SiteAnalyticsContextValue = {
   route: "",
@@ -109,6 +143,7 @@ export const getAnalyticsSessionId = () => {
 
   const nextSessionId = createAnalyticsId();
   storage?.setItem(ANALYTICS_SESSION_KEY, nextSessionId);
+  storage?.removeItem(ANALYTICS_ENTRY_CONTEXT_KEY);
   return nextSessionId;
 };
 
@@ -172,11 +207,152 @@ export const getReferrerType = (referrer: string, hostname: string) => {
   }
 
   try {
-    const referrerHostname = new URL(referrer).hostname;
-    return referrerHostname === hostname ? ("internal" as const) : ("external" as const);
+    const referrerHostname = new URL(referrer).hostname.trim().toLowerCase();
+    const normalizedHostname = hostname.trim().toLowerCase();
+    return referrerHostname === normalizedHostname ? ("internal" as const) : ("external" as const);
   } catch {
     return "unknown" as const;
   }
+};
+
+const normalizeAnalyticsToken = (value: string) => {
+  const normalizedValue = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, ANALYTICS_VALUE_MAX_LENGTH);
+
+  return normalizedValue || undefined;
+};
+
+const hasHostnameSuffix = (hostname: string, suffix: string) =>
+  hostname === suffix || hostname.endsWith(`.${suffix}`);
+
+export const getReferrerDomainBucket = (
+  referrer: string,
+  hostname: string
+): ReferrerDomainBucket => {
+  const referrerType = getReferrerType(referrer, hostname);
+  if (referrerType === "direct" || referrerType === "internal" || referrerType === "unknown") {
+    return referrerType;
+  }
+
+  try {
+    const referrerHostname = new URL(referrer).hostname.trim().toLowerCase();
+    if (hasHostnameSuffix(referrerHostname, "lu.ma") || referrerHostname.includes("luma")) {
+      return "luma";
+    }
+    if (referrerHostname.includes("google.")) {
+      return "google";
+    }
+    if (
+      hasHostnameSuffix(referrerHostname, "linkedin.com") ||
+      hasHostnameSuffix(referrerHostname, "lnkd.in")
+    ) {
+      return "linkedin";
+    }
+    if (
+      hasHostnameSuffix(referrerHostname, "facebook.com") ||
+      hasHostnameSuffix(referrerHostname, "fb.com")
+    ) {
+      return "facebook";
+    }
+    if (hasHostnameSuffix(referrerHostname, "instagram.com")) {
+      return "instagram";
+    }
+    if (hasHostnameSuffix(referrerHostname, "github.com")) {
+      return "github";
+    }
+  } catch {
+    return "unknown";
+  }
+
+  return "other_external";
+};
+
+const UTM_FIELD_PROPERTY_MAP = {
+  source: "utm_source",
+  medium: "utm_medium",
+  campaign: "utm_campaign",
+  content: "utm_content",
+  term: "utm_term",
+} as const;
+
+export const getCampaignContext = (locationSearch: string): CampaignContext => {
+  const searchParams = new URLSearchParams(locationSearch);
+  const trafficTypeParam = normalizeAnalyticsToken(searchParams.get("traffic_type") ?? "");
+  const qaParam = normalizeAnalyticsToken(searchParams.get("qa") ?? "");
+  const trafficType: AnalyticsTrafficType =
+    trafficTypeParam === "internal_qa" || qaParam === "1" ? "internal_qa" : "public";
+  const campaignContext: CampaignContext = { traffic_type: trafficType };
+
+  Object.entries(UTM_FIELD_PROPERTY_MAP).forEach(([queryKey, propertyKey]) => {
+    const normalizedValue = normalizeAnalyticsToken(searchParams.get(`utm_${queryKey}`) ?? "");
+    if (normalizedValue) {
+      campaignContext[propertyKey] = normalizedValue;
+    }
+  });
+
+  return campaignContext;
+};
+
+const isTrafficType = (value: unknown): value is AnalyticsTrafficType =>
+  value === "public" || value === "internal_qa";
+
+const getAnalyticsEntryContext = ({
+  route,
+  referrerType,
+  referrerDomainBucket,
+  campaignContext,
+}: {
+  route: string;
+  referrerType: SessionEntryContext["session_entry_referrer_type"];
+  referrerDomainBucket: ReferrerDomainBucket;
+  campaignContext: CampaignContext;
+}): SessionEntryContext => {
+  const storage = getSessionStorage();
+  const storedContext = storage?.getItem(ANALYTICS_ENTRY_CONTEXT_KEY);
+  if (storedContext) {
+    try {
+      const parsedContext = JSON.parse(storedContext) as SessionEntryContext;
+      if (isTrafficType(parsedContext.traffic_type)) {
+        const nextContext = {
+          ...parsedContext,
+          traffic_type:
+            campaignContext.traffic_type === "internal_qa"
+              ? ("internal_qa" as const)
+              : parsedContext.traffic_type,
+        };
+        if (nextContext.traffic_type !== parsedContext.traffic_type) {
+          storage?.setItem(ANALYTICS_ENTRY_CONTEXT_KEY, JSON.stringify(nextContext));
+        }
+        return nextContext;
+      }
+    } catch {
+      storage?.removeItem(ANALYTICS_ENTRY_CONTEXT_KEY);
+    }
+  }
+
+  const entryContext: SessionEntryContext = {
+    traffic_type: campaignContext.traffic_type,
+    session_entry_route: route,
+    session_entry_referrer_type: referrerType,
+    session_entry_referrer_domain_bucket: referrerDomainBucket,
+  };
+
+  if (campaignContext.utm_source) {
+    entryContext.session_entry_utm_source = campaignContext.utm_source;
+  }
+  if (campaignContext.utm_medium) {
+    entryContext.session_entry_utm_medium = campaignContext.utm_medium;
+  }
+  if (campaignContext.utm_campaign) {
+    entryContext.session_entry_utm_campaign = campaignContext.utm_campaign;
+  }
+
+  storage?.setItem(ANALYTICS_ENTRY_CONTEXT_KEY, JSON.stringify(entryContext));
+  return entryContext;
 };
 
 export const createSiteAnalyticsPayload = ({
@@ -188,6 +364,7 @@ export const createSiteAnalyticsPayload = ({
   now = new Date(),
   locationHostname,
   referrer,
+  locationSearch = "",
   viewportWidth,
 }: {
   eventName: SiteAnalyticsEventName;
@@ -198,10 +375,26 @@ export const createSiteAnalyticsPayload = ({
   now?: Date;
   locationHostname: string;
   referrer: string;
+  locationSearch?: string;
   viewportWidth: number;
 }): SiteAnalyticsPayload => {
   const environment = getAnalyticsEnvironment(locationHostname);
   const viewport = getViewportContext(viewportWidth);
+  const referrerType = getReferrerType(referrer, environment.hostname);
+  const referrerDomainBucket = getReferrerDomainBucket(referrer, environment.hostname);
+  const campaignContext = getCampaignContext(locationSearch);
+  const sessionEntryContext = getAnalyticsEntryContext({
+    route,
+    referrerType,
+    referrerDomainBucket,
+    campaignContext,
+  });
+  const analyticsProperties: SiteAnalyticsProperties = {
+    ...properties,
+    ...campaignContext,
+    referrer_domain_bucket: referrerDomainBucket,
+    ...sessionEntryContext,
+  };
 
   return {
     event_id: createAnalyticsId(),
@@ -219,8 +412,8 @@ export const createSiteAnalyticsPayload = ({
     is_production_domain: environment.is_production_domain,
     viewport_bucket: viewport.viewport_bucket,
     device_class: viewport.device_class,
-    referrer_type: getReferrerType(referrer, environment.hostname),
-    properties,
+    referrer_type: referrerType,
+    properties: analyticsProperties,
     experiments: [],
   };
 };
@@ -319,6 +512,7 @@ export const SiteAnalyticsScope = ({
         analyticsSessionId,
         locationHostname: window.location.hostname,
         referrer: document.referrer,
+        locationSearch: window.location.search,
         viewportWidth: window.innerWidth,
       }),
       options.beacon


### PR DESCRIPTION
## 요약
- 작업 ID: #231
- 홍보 효과 분석을 위해 홈페이지/데모 analytics payload에 UTM, QA 트래픽 구분, 안전한 referrer bucket, 세션 최초 진입 맥락을 추가했습니다.
- backend analytics validation에서 새 속성의 allowlist와 저카디널리티 토큰 형식을 검증하도록 보강했습니다.

## Impact Trigger
- [x] BE/FE 다중 도메인 변경
- [x] API payload validation 변경
- [ ] docs/*.md source-of-truth 변경
- [ ] CI/CD, 배포, 보안, ingress, secret, runtime topology 변경

## 영향 도메인
- [x] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra

## 변경 사항
- 프론트 analytics payload에 `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term` 정규화 수집을 추가했습니다.
- `traffic_type=internal_qa` 또는 `qa=1`이면 `traffic_type: internal_qa`로 기록하고, 기본값은 `public`으로 둡니다.
- raw URL/query/referrer path를 저장하지 않고 `referrer_domain_bucket`만 저장합니다.
- 세션 최초 진입 맥락(`session_entry_route`, 최초 referrer/UTM)을 sessionStorage에 보관해 이후 이벤트에도 함께 보냅니다.
- backend에서 허용된 UTM key, `traffic_type`, referrer bucket, session entry 값을 검증합니다.
- frontend/backend 단위 테스트를 추가했습니다.

## 검증
- 테스트:
  - `npm test -- siteAnalytics`
  - `/home/ubuntu/.openclaw/workspace-bingo/frontend/node_modules/.bin/tsc --noEmit`
  - `npm run lint`
  - `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests/test_analytics_routes.py -q`
- 결과:
  - frontend siteAnalytics 테스트 6개 통과
  - TypeScript typecheck 통과
  - frontend lint 통과
  - backend analytics route 테스트 10개 통과
- 참고:
  - backend 테스트에서 기존 Pydantic deprecation warning 1개가 출력됩니다.

## 가이드 동기화
- docs source-of-truth 변경 없음. Korean mirror 동기화 대상 없음.

## 핸드오프
- 별도 handoff 문서는 추가하지 않았습니다. 변경 범위와 검증 내용은 이 PR 본문에 기록했습니다.

Closes #231
