### PR TITLE
fix(events): 공개 행사 목록 노출 제한

### DIFF
--- a/backend/app/api/events/routes.py
+++ b/backend/app/api/events/routes.py
@@ -21,7 +21,6 @@ from .schema import (
     PublicEventProfileResponse,
     PublicPolicyTemplateItem,
     PublicPolicyTemplateResponse,
-    PublicEventSummaryItem,
 )
 
 
@@ -46,27 +45,11 @@ def normalize_event_manager_request_purpose(event_purpose: str | None) -> str:
     response_model=PublicEventListResponse,
     summary="공개 이벤트 목록 조회",
 )
-async def list_public_events(
-    db: AsyncSessionDepends,
-):
-    events = await Event.get_all(db)
-    event_items = [
-        PublicEventSummaryItem(
-            id=event.id,
-            slug=event.slug,
-            name=event.name,
-            start_at=event.start_time,
-            board_size=event.bingo_size,
-            bingo_mission_count=event.success_condition,
-            status=resolve_public_event_status(event),
-        )
-        for event in events
-    ]
-
+async def list_public_events():
     return PublicEventListResponse(
         ok=True,
-        message="이벤트 목록을 불러왔습니다.",
-        events=event_items,
+        message="공개 이벤트 목록은 제공하지 않습니다.",
+        events=[],
     )
 
 

--- a/backend/app/tests/test_event_routes.py
+++ b/backend/app/tests/test_event_routes.py
@@ -6,9 +6,11 @@ import api.events.routes as event_routes
 from api.events.routes import (
     events_router,
     get_public_policy_template,
+    list_public_events,
     normalize_event_manager_request_purpose,
 )
 from api.events.schema import EventManagerRequestCreateRequest
+from models.event import Event
 from models.event_manager_request import EventManagerRequest, EventManagerRequestStatus
 from models.policy_template import PLATFORM_PRIVACY_POLICY_UPDATED_AT
 
@@ -22,6 +24,18 @@ def test_events_router_exposes_public_catalog_and_application_endpoints():
     assert "/events/{event_slug}/privacy-notice-template" in paths
     assert "/events/manager-requests" in paths
     assert "/events/{event_slug}" in paths
+
+
+def test_public_catalog_does_not_enumerate_events(monkeypatch):
+    async def fail_get_all(_session):
+        raise AssertionError("public catalog must not enumerate all events")
+
+    monkeypatch.setattr(Event, "get_all", fail_get_all)
+
+    response = asyncio.run(list_public_events())
+
+    assert response.ok is True
+    assert response.events == []
 
 
 def test_public_platform_policy_endpoint_returns_code_defined_static_policy():


### PR DESCRIPTION
## 요약
- 작업 ID: 없음 (운영 정책 확인에 따른 후속 패치)
- 개별 행사 페이지(`/event/{slug}`)와 행사 상세 API는 유지하되, `GET /api/events`가 전체 행사 목록을 공개 열거하지 않도록 제한했습니다.
- 현재 별도 공개 catalog 플래그가 없으므로 목록 API는 빈 배열을 반환합니다.

## Impact Trigger
- [ ] BE/FE 다중 도메인 변경
- [x] API 동작 변경
- [ ] docs/*.md source-of-truth 변경
- [ ] CI/CD, 배포, 보안, ingress, secret, runtime topology 변경

## 영향 도메인
- [x] BE (`backend/**`)
- [ ] FE (`frontend/**`)
- [ ] Infra

## 변경 사항
- `GET /api/events`에서 `Event.get_all()` 전체 조회를 제거했습니다.
- 공개 목록 API는 200 응답과 빈 `events` 배열을 반환합니다.
- `/api/events/{event_slug}` 상세 조회, `/event/{slug}` SEO 응답, 참가자/개인정보 안내 경로는 유지됩니다.
- 전체 행사 목록이 공개 API로 열거되지 않는 테스트를 추가했습니다.

## 검증
- 테스트:
  - `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests/test_event_routes.py -q`
- 결과:
  - 7 passed
- 참고:
  - 기존 Pydantic deprecation warning 1개가 출력됩니다.

## 가이드 동기화
- docs source-of-truth 변경 없음. Korean mirror 동기화 대상 없음.

## 핸드오프
- 별도 handoff 문서는 추가하지 않았습니다. 변경 범위와 검증 내용은 이 PR 본문에 기록했습니다.
