### PR TITLE
fix(admin): 행사 목록 조회 범위 제한

### DIFF
--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -164,6 +164,14 @@ def filter_visible_admin_events(actor: Admin, events: list[Event]) -> list[Event
     return [event for event in events if event.admin_id == actor.id]
 
 
+def build_visible_admin_events_query(actor: Admin):
+    query = select(Event).order_by(Event.start_time.desc())
+    if actor.role != AdminRole.ADMIN:
+        query = query.where(Event.admin_id == actor.id)
+
+    return query
+
+
 def validate_event_schedule(start_at: datetime, end_at: datetime) -> None:
     if end_at <= start_at:
         raise ValueError("행사 종료 시각은 시작 시각보다 늦어야 합니다.")

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -30,10 +30,10 @@ from .console_services import (
     build_admin_event_bingo_progress_query,
     build_event_detail,
     build_event_rooms,
+    build_visible_admin_events_query,
     can_edit_event,
     can_view_event,
     ensure_admin_console_seed_data,
-    filter_visible_admin_events,
     kick_event_attendee,
     normalize_event_keywords,
     reset_event_runtime_data,
@@ -374,7 +374,8 @@ async def list_admin_events(
     from .schema import AdminEventSummary
 
     await ensure_admin_console_seed_data(db)
-    events = filter_visible_admin_events(actor, await Event.get_all(db))
+    event_rows = await db.execute(build_visible_admin_events_query(actor))
+    events = event_rows.scalars().all()
 
     if not events:
         return AdminEventListResponse(ok=True, message="이벤트 목록을 불러왔습니다.", events=[])

--- a/backend/app/tests/test_admin_console_services.py
+++ b/backend/app/tests/test_admin_console_services.py
@@ -5,6 +5,7 @@ from api.admin.console_services import (
     build_archive_participant_alias,
     build_admin_event_bingo_progress_query,
     build_admin_console_link,
+    build_visible_admin_events_query,
     can_view_event,
     filter_visible_admin_events,
     is_event_personal_data_expired,
@@ -53,6 +54,24 @@ def test_filter_visible_admin_events_limits_event_manager_to_owned_events():
     other_event = type("EventStub", (), {"id": 30, "admin_id": 3})()
 
     assert filter_visible_admin_events(actor, [owned_event, other_event]) == [owned_event]
+
+
+def test_build_visible_admin_events_query_allows_admin_to_query_all_events():
+    actor = type("AdminStub", (), {"id": 1, "role": AdminRole.ADMIN})()
+
+    statement = str(build_visible_admin_events_query(actor))
+
+    assert "WHERE" not in statement
+    assert "ORDER BY events.start_time DESC" in statement
+
+
+def test_build_visible_admin_events_query_limits_event_manager_to_owned_events():
+    actor = type("AdminStub", (), {"id": 2, "role": AdminRole.EVENT_MANAGER})()
+
+    statement = str(build_visible_admin_events_query(actor))
+
+    assert "WHERE events.admin_id = " in statement
+    assert "ORDER BY events.start_time DESC" in statement
 
 
 def test_can_view_event_blocks_event_manager_from_other_owner_event():

--- a/backend/app/tests/test_admin_routes.py
+++ b/backend/app/tests/test_admin_routes.py
@@ -1,7 +1,67 @@
 import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from api.admin import auth as admin_auth
+import api.admin.routes as admin_routes
 from api.admin.routes import admin_router
+from models.admin import AdminRole
+from models.event import EventStatus, GameMode
+
+
+class _FakeScalarResult:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+class _FakeExecuteResult:
+    def __init__(self, *, scalar_items=None, rows=None):
+        self._scalar_items = scalar_items or []
+        self._rows = rows or []
+
+    def scalars(self):
+        return _FakeScalarResult(self._scalar_items)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _AdminEventListDb:
+    def __init__(self, execute_results):
+        self._execute_results = list(execute_results)
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(str(statement))
+        return self._execute_results.pop(0)
+
+
+def _admin_stub(admin_id: int, role: AdminRole):
+    return SimpleNamespace(id=admin_id, email=f"admin-{admin_id}@example.com", name=f"Admin {admin_id}", role=role)
+
+
+def _event_stub(event_id: int, admin_id: int, name: str):
+    now = datetime(2026, 6, 5, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=event_id,
+        slug=f"event-{event_id}",
+        name=name,
+        admin_id=admin_id,
+        location="서울",
+        event_team="DevFactory",
+        start_time=now,
+        end_time=now,
+        admin_email=f"owner-{admin_id}@example.com",
+        bingo_size=5,
+        success_condition=3,
+        keywords=["AI", "Networking"],
+        game_mode=GameMode.INDIVIDUAL,
+        team_size=1,
+        status=EventStatus.IN_PROGRESS,
+    )
 
 
 def test_admin_router_exposes_google_admin_endpoints_only():
@@ -13,6 +73,57 @@ def test_admin_router_exposes_google_admin_endpoints_only():
     assert "/admin/auth/login" not in paths
     assert "/admin/invitations/{invite_token}" not in paths
     assert "/admin/invitations/{invite_token}/complete" not in paths
+
+
+def test_list_admin_events_route_limits_event_manager_to_owned_events(monkeypatch):
+    async def skip_seed(_db):
+        return None
+
+    actor = _admin_stub(2, AdminRole.EVENT_MANAGER)
+    owned_event = _event_stub(20, 2, "내 행사")
+    creator = _admin_stub(2, AdminRole.EVENT_MANAGER)
+    db = _AdminEventListDb(
+        [
+            _FakeExecuteResult(scalar_items=[owned_event]),
+            _FakeExecuteResult(scalar_items=[creator]),
+            _FakeExecuteResult(rows=[]),
+            _FakeExecuteResult(rows=[]),
+        ]
+    )
+    monkeypatch.setattr(admin_routes, "ensure_admin_console_seed_data", skip_seed)
+
+    response = asyncio.run(admin_routes.list_admin_events(db, actor))
+
+    assert "WHERE events.admin_id = " in db.statements[0]
+    assert response.ok is True
+    assert [event.id for event in response.events] == [20]
+    assert response.events[0].created_by_id == actor.id
+    assert response.events[0].can_edit is True
+
+
+def test_list_admin_events_route_keeps_full_scope_for_admin(monkeypatch):
+    async def skip_seed(_db):
+        return None
+
+    actor = _admin_stub(1, AdminRole.ADMIN)
+    first_event = _event_stub(10, 1, "첫 번째 행사")
+    second_event = _event_stub(20, 2, "두 번째 행사")
+    db = _AdminEventListDb(
+        [
+            _FakeExecuteResult(scalar_items=[first_event, second_event]),
+            _FakeExecuteResult(scalar_items=[_admin_stub(1, AdminRole.ADMIN), _admin_stub(2, AdminRole.EVENT_MANAGER)]),
+            _FakeExecuteResult(rows=[]),
+            _FakeExecuteResult(rows=[]),
+        ]
+    )
+    monkeypatch.setattr(admin_routes, "ensure_admin_console_seed_data", skip_seed)
+
+    response = asyncio.run(admin_routes.list_admin_events(db, actor))
+
+    assert "WHERE" not in db.statements[0]
+    assert response.ok is True
+    assert [event.id for event in response.events] == [10, 20]
+    assert all(event.can_edit for event in response.events)
 
 
 def test_fetch_supabase_user_payload_uses_supabase_auth_user(monkeypatch):


### PR DESCRIPTION
## 변경 내용
- 관리자 행사 목록 조회에서 role별 조회 범위를 DB 쿼리 단계로 분리했습니다.
- `admin`은 전체 행사를 조회하고, `event_manager` 등 비-admin 계정은 본인 소유 행사만 조회하도록 했습니다.
- 향후 co-host 등 추가 접근 정책을 확장할 수 있도록 목록 scope 생성 함수를 분리했습니다.
- query 단위와 route 단위 회귀 테스트를 추가했습니다.

## 검증
- `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests/test_admin_console_services.py app/tests/test_admin_routes.py`
- 결과: 33 passed, 1 warning
- warning은 기존 Pydantic v2 deprecation 경고이며 이번 변경과 직접 관련 없습니다.

## 영향 및 후속
- Backend admin API 변경입니다.
- DB schema 변경, frontend 변경, 배포 manifest 변경은 없습니다.
- co-host 권한은 별도 이슈/PR로 분리하는 것이 적절합니다.