### PR TITLE
feat(backend): 행사 co-host 권한 모델 추가

### DIFF
--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -12,13 +12,14 @@ import smtplib
 from urllib.parse import urlsplit, urlunsplit
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import and_, delete, func, select
+from sqlalchemy import and_, delete, func, or_, select
 
 from core.db import AsyncSession
 from models.admin import Admin, AdminRole
 from models.bingo.bingo_boards import BingoBoards
 from models.bingo.bingo_interaction import BingoInteraction
 from models.event import Event, EventStatus
+from models.event_co_host import EventCoHost
 from models.event_attendee import EventAttendee
 from models.event_manager_request import EventManagerRequest, EventManagerRequestStatus
 from models.policy_template import PolicyTemplate
@@ -149,12 +150,24 @@ async def serialize_policy_template(
     )
 
 
-def can_edit_event(actor: Admin, event: Event) -> bool:
-    return can_view_event(actor, event)
+async def is_event_co_host(session: AsyncSession, actor: Admin, event: Event) -> bool:
+    if actor.role == AdminRole.ADMIN or actor.id == event.admin_id:
+        return False
+
+    co_host = await EventCoHost.get_by_event_and_admin(session, event.id, actor.id)
+    return co_host is not None
 
 
-def can_view_event(actor: Admin, event: Event) -> bool:
-    return actor.role == AdminRole.ADMIN or actor.id == event.admin_id
+async def can_edit_event(session: AsyncSession, actor: Admin, event: Event) -> bool:
+    return can_manage_owner_scope(actor, event)
+
+
+async def can_view_event(session: AsyncSession, actor: Admin, event: Event) -> bool:
+    return (
+        actor.role == AdminRole.ADMIN
+        or actor.id == event.admin_id
+        or await is_event_co_host(session, actor, event)
+    )
 
 
 def filter_visible_admin_events(actor: Admin, events: list[Event]) -> list[Event]:
@@ -164,10 +177,22 @@ def filter_visible_admin_events(actor: Admin, events: list[Event]) -> list[Event
     return [event for event in events if event.admin_id == actor.id]
 
 
+def can_manage_owner_scope(actor: Admin, event: Event) -> bool:
+    return actor.role == AdminRole.ADMIN or actor.id == event.admin_id
+
+
 def build_visible_admin_events_query(actor: Admin):
     query = select(Event).order_by(Event.start_time.desc())
     if actor.role != AdminRole.ADMIN:
-        query = query.where(Event.admin_id == actor.id)
+        co_host_exists = (
+            select(EventCoHost.id)
+            .where(
+                EventCoHost.event_id == Event.id,
+                EventCoHost.admin_id == actor.id,
+            )
+            .exists()
+        )
+        query = query.where(or_(Event.admin_id == actor.id, co_host_exists))
 
     return query
 
@@ -517,7 +542,7 @@ async def build_event_summary(
         progress_current=progress_current,
         progress_total=participant_count,
         status=resolve_event_status(event),
-        can_edit=can_edit_event(actor, event),
+        can_edit=await can_edit_event(session, actor, event),
     )
 
 
@@ -626,7 +651,7 @@ async def build_event_detail(
         progress_current=progress_current,
         progress_total=participant_count,
         status=resolve_event_status(event),
-        can_edit=can_edit_event(actor, event),
+        can_edit=await can_edit_event(session, actor, event),
     )
     return AdminEventDetail(
         **summary.model_dump(),

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -32,6 +32,7 @@ from .console_services import (
     build_event_rooms,
     build_visible_admin_events_query,
     can_edit_event,
+    can_manage_owner_scope,
     can_view_event,
     ensure_admin_console_seed_data,
     kick_event_attendee,
@@ -432,7 +433,7 @@ async def list_admin_events(
                 progress_current=progress_current,
                 progress_total=participant_count,
                 status=resolve_event_status(event),
-                can_edit=can_edit_event(actor, event),
+                can_edit=can_manage_owner_scope(actor, event),
             )
         )
 
@@ -455,7 +456,7 @@ async def get_admin_event(
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
-    if not can_view_event(actor, event):
+    if not await can_view_event(db, actor, event):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="이 이벤트를 조회할 권한이 없습니다.",
@@ -516,7 +517,7 @@ async def update_admin_event(
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
-    if not can_edit_event(actor, event):
+    if not can_manage_owner_scope(actor, event):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="이 이벤트는 읽기 전용입니다.",
@@ -564,10 +565,10 @@ async def reset_admin_event_data(
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
-    if not can_edit_event(actor, event):
+    if not can_manage_owner_scope(actor, event):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="이 이벤트는 읽기 전용입니다.",
+            detail="이 이벤트 데이터를 초기화할 권한이 없습니다.",
         )
 
     stats = await reset_event_runtime_data(db, event)
@@ -594,7 +595,7 @@ async def list_admin_event_rooms(
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
-    if not can_view_event(actor, event):
+    if not await can_view_event(db, actor, event):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="이 이벤트를 조회할 권한이 없습니다.",
@@ -626,7 +627,7 @@ async def kick_admin_event_attendee(
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
-    if not can_edit_event(actor, event):
+    if not can_manage_owner_scope(actor, event):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="이 이벤트를 관리할 권한이 없습니다.",

--- a/backend/app/migrations/versions/b7d2c8a41e90_add_event_co_hosts.py
+++ b/backend/app/migrations/versions/b7d2c8a41e90_add_event_co_hosts.py
@@ -1,0 +1,48 @@
+"""add event co-hosts table
+
+Revision ID: b7d2c8a41e90
+Revises: 8f4b2d9c1a30
+Create Date: 2026-06-06 17:35:00.000000+09:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7d2c8a41e90"
+down_revision: Union[str, None] = "8f4b2d9c1a30"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_co_hosts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("admin_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["admin_id"], ["admins.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "admin_id", name="uq_event_co_hosts_event_admin"),
+    )
+    op.create_index(
+        "ix_event_co_hosts_admin_id_event_id",
+        "event_co_hosts",
+        ["admin_id", "event_id"],
+    )
+    op.create_index(
+        "ix_event_co_hosts_event_id",
+        "event_co_hosts",
+        ["event_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_event_co_hosts_event_id", table_name="event_co_hosts")
+    op.drop_index("ix_event_co_hosts_admin_id_event_id", table_name="event_co_hosts")
+    op.drop_table("event_co_hosts")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from models.user import BingoUser
 from models.bingo import BingoBoards, BingoInteraction
 from models.admin import Admin, AdminRole
 from models.event import Event, EventStatus, EventPublishState
+from models.event_co_host import EventCoHost
 from models.event_manager_request import EventManagerRequest, EventManagerRequestStatus
 from models.room import Room
 from models.team import Team, TeamColor

--- a/backend/app/models/event_co_host.py
+++ b/backend/app/models/event_co_host.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import DateTime, ForeignKey, Integer, UniqueConstraint, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.db import AsyncSession
+from models.base import Base
+
+
+class EventCoHost(Base):
+    __tablename__ = "event_co_hosts"
+    __table_args__ = (
+        UniqueConstraint("event_id", "admin_id", name="uq_event_co_hosts_event_admin"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
+    event_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("events.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    admin_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("admins.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(ZoneInfo("Asia/Seoul")),
+        nullable=False,
+    )
+
+    @classmethod
+    async def create(
+        cls,
+        session: AsyncSession,
+        event_id: int,
+        admin_id: int,
+    ) -> "EventCoHost":
+        from models.admin import Admin
+        from models.event import Event
+
+        await Event.get_by_id(session, event_id)
+        await Admin.get_by_id(session, admin_id)
+
+        existing = await session.execute(
+            select(cls).where(cls.event_id == event_id, cls.admin_id == admin_id)
+        )
+        if existing.scalar_one_or_none():
+            raise ValueError(f"Admin {admin_id}는 이미 Event {event_id}의 co-host입니다.")
+
+        co_host = EventCoHost(event_id=event_id, admin_id=admin_id)
+        session.add(co_host)
+        await session.commit()
+        await session.refresh(co_host)
+        return co_host
+
+    @classmethod
+    async def get_by_event(cls, session: AsyncSession, event_id: int) -> list["EventCoHost"]:
+        result = await session.execute(select(cls).where(cls.event_id == event_id))
+        return list(result.scalars().all())
+
+    @classmethod
+    async def get_by_admin(cls, session: AsyncSession, admin_id: int) -> list["EventCoHost"]:
+        result = await session.execute(select(cls).where(cls.admin_id == admin_id))
+        return list(result.scalars().all())
+
+    @classmethod
+    async def get_by_event_and_admin(
+        cls,
+        session: AsyncSession,
+        event_id: int,
+        admin_id: int,
+    ) -> Optional["EventCoHost"]:
+        result = await session.execute(
+            select(cls).where(cls.event_id == event_id, cls.admin_id == admin_id)
+        )
+        return result.scalar_one_or_none()

--- a/backend/app/tests/test_admin_console_services.py
+++ b/backend/app/tests/test_admin_console_services.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import api.admin.console_services as console_services
 import pytest
 
@@ -6,6 +8,7 @@ from api.admin.console_services import (
     build_admin_event_bingo_progress_query,
     build_admin_console_link,
     build_visible_admin_events_query,
+    can_manage_owner_scope,
     can_view_event,
     filter_visible_admin_events,
     is_event_personal_data_expired,
@@ -56,6 +59,17 @@ def test_filter_visible_admin_events_limits_event_manager_to_owned_events():
     assert filter_visible_admin_events(actor, [owned_event, other_event]) == [owned_event]
 
 
+def test_can_manage_owner_scope_allows_admin_and_owner_only():
+    admin = type("AdminStub", (), {"id": 1, "role": AdminRole.ADMIN})()
+    owner = type("AdminStub", (), {"id": 2, "role": AdminRole.EVENT_MANAGER})()
+    co_host = type("AdminStub", (), {"id": 3, "role": AdminRole.EVENT_MANAGER})()
+    event = type("EventStub", (), {"id": 30, "admin_id": 2})()
+
+    assert can_manage_owner_scope(admin, event) is True
+    assert can_manage_owner_scope(owner, event) is True
+    assert can_manage_owner_scope(co_host, event) is False
+
+
 def test_build_visible_admin_events_query_allows_admin_to_query_all_events():
     actor = type("AdminStub", (), {"id": 1, "role": AdminRole.ADMIN})()
 
@@ -65,20 +79,30 @@ def test_build_visible_admin_events_query_allows_admin_to_query_all_events():
     assert "ORDER BY events.start_time DESC" in statement
 
 
-def test_build_visible_admin_events_query_limits_event_manager_to_owned_events():
+def test_build_visible_admin_events_query_limits_event_manager_to_owned_or_co_host_events():
     actor = type("AdminStub", (), {"id": 2, "role": AdminRole.EVENT_MANAGER})()
 
     statement = str(build_visible_admin_events_query(actor))
 
     assert "WHERE events.admin_id = " in statement
+    assert "event_co_hosts" in statement
     assert "ORDER BY events.start_time DESC" in statement
 
 
 def test_can_view_event_blocks_event_manager_from_other_owner_event():
     actor = type("AdminStub", (), {"id": 2, "role": AdminRole.EVENT_MANAGER})()
-    event = type("EventStub", (), {"admin_id": 3})()
+    event = type("EventStub", (), {"id": 30, "admin_id": 3})()
 
-    assert can_view_event(actor, event) is False
+    class DbStub:
+        async def execute(self, _statement):
+            class Result:
+                @staticmethod
+                def scalar_one_or_none():
+                    return None
+
+            return Result()
+
+    assert asyncio.run(can_view_event(DbStub(), actor, event)) is False
 
 
 def test_normalize_event_keywords_autofills_remaining_slots():

--- a/backend/app/tests/test_admin_routes.py
+++ b/backend/app/tests/test_admin_routes.py
@@ -25,6 +25,9 @@ class _FakeExecuteResult:
     def scalars(self):
         return _FakeScalarResult(self._scalar_items)
 
+    def scalar_one_or_none(self):
+        return self._scalar_items[0] if self._scalar_items else None
+
     def __iter__(self):
         return iter(self._rows)
 
@@ -99,6 +102,33 @@ def test_list_admin_events_route_limits_event_manager_to_owned_events(monkeypatc
     assert [event.id for event in response.events] == [20]
     assert response.events[0].created_by_id == actor.id
     assert response.events[0].can_edit is True
+
+
+def test_list_admin_events_route_includes_co_host_events(monkeypatch):
+    async def skip_seed(_db):
+        return None
+
+    actor = _admin_stub(2, AdminRole.EVENT_MANAGER)
+    co_host_event = _event_stub(30, 3, "공동 운영 행사")
+    creator = _admin_stub(3, AdminRole.EVENT_MANAGER)
+    db = _AdminEventListDb(
+        [
+            _FakeExecuteResult(scalar_items=[co_host_event]),
+            _FakeExecuteResult(scalar_items=[creator]),
+            _FakeExecuteResult(rows=[]),
+            _FakeExecuteResult(rows=[]),
+            _FakeExecuteResult(scalar_items=[SimpleNamespace(id=1)]),
+        ]
+    )
+    monkeypatch.setattr(admin_routes, "ensure_admin_console_seed_data", skip_seed)
+
+    response = asyncio.run(admin_routes.list_admin_events(db, actor))
+
+    assert "event_co_hosts" in db.statements[0]
+    assert response.ok is True
+    assert [event.id for event in response.events] == [30]
+    assert response.events[0].created_by_id == 3
+    assert response.events[0].can_edit is False
 
 
 def test_list_admin_events_route_keeps_full_scope_for_admin(monkeypatch):


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: co-host backend 1차 구현
- 행사 공동 운영자 권한을 표현하는 `event_co_hosts` 모델과 Alembic 마이그레이션을 추가했습니다.
- Admin 행사 목록/상세 조회 권한에 co-host를 포함했습니다.
- 행사 수정, 데이터 초기화, 참가자 강퇴 같은 mutation은 owner/admin 권한으로 유지했습니다.
- co-host 포함 목록 조회, 읽기 전용 `can_edit` 상태, owner-only 권한 회귀 테스트를 보강했습니다.

## Impact Trigger (Select At Least One)
- [ ] Cross-domain change (BE/FE/Infra)
- [x] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [x] BE (`backend/**`)
- [ ] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [x] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [x] docs/reference/agent-collaboration.md

## Changes
- `backend/app/models/event_co_host.py`: 행사별 co-host 관계 모델 추가
- `backend/app/migrations/versions/b7d2c8a41e90_add_event_co_hosts.py`: `event_co_hosts` 테이블, unique constraint, 조회 index 추가
- `backend/app/api/admin/console_services.py`: 행사 조회 권한과 목록 query에 co-host 포함, owner/admin 전용 mutation 권한 helper 추가
- `backend/app/api/admin/routes.py`: 상세/목록은 co-host 조회 가능, 수정/초기화/강퇴는 owner/admin만 가능하도록 권한 분리
- `backend/app/tests/test_admin_console_services.py`, `backend/app/tests/test_admin_routes.py`: co-host 목록 포함, 읽기 전용 상태, owner-only 권한 회귀 테스트 추가

## Validation
- Tests:
  - `PYTHONPATH=backend/app /tmp/bingo-cohost-venv/bin/pytest backend/app/tests/test_admin_console_services.py backend/app/tests/test_admin_routes.py`
  - `PYTHONPATH=app /tmp/bingo-cohost-venv/bin/alembic heads`
- Result:
  - 35 passed, 1 warning
  - Alembic head: `b7d2c8a41e90 (head)`
- Not run and reason:
  - 전체 테스트는 실행하지 않았습니다. 이번 변경은 BE admin 권한/마이그레이션 범위라 관련 테스트와 Alembic head 확인으로 제한했습니다.

## Guide Sync Check
- [x] Updated Korean mirrors for changed English guides
- 문서 변경 없음. 영어 guide를 수정하지 않아 mirror sync 대상이 없습니다.

## Handoff
- [ ] Added handoff note following docs/templates/agent-handoff.md
- 별도 handoff 문서는 추가하지 않았습니다. 변경 범위는 BE 단일 도메인이고 PR 본문에 변경/검증/후속을 기록했습니다.

## Follow-up
- co-host 지정/해제 API 추가
- Admin UI에서 공동 운영자 관리 화면 연결
- 참가 비활성화는 운영 정책을 정한 뒤 별도 작업으로 진행