### PR TITLE
이벤트 관리자 승인 메일 문구 정리

### DIFF
--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -246,7 +246,7 @@ def build_admin_console_link() -> str:
 
 def _build_access_granted_email(name: str, console_url: str) -> EmailMessage:
     message = EmailMessage()
-    message["Subject"] = "[Event Bingo] 관리자 권한이 승인되었습니다"
+    message["Subject"] = "[Event Bingo] 이벤트 관리자 권한이 승인되었습니다"
     message["From"] = formataddr((ADMIN_SMTP_FROM_NAME, ADMIN_SMTP_FROM_EMAIL or "no-reply@example.com"))
     if ADMIN_SMTP_REPLY_TO:
         message["Reply-To"] = ADMIN_SMTP_REPLY_TO
@@ -256,8 +256,8 @@ def _build_access_granted_email(name: str, console_url: str) -> EmailMessage:
                 f"{name}님, 안녕하세요.",
                 "",
                 "DevFactory 운영팀입니다.",
-                "Event Bingo 관리자 권한 신청이 승인되었습니다.",
-                "이제 승인된 이메일로 Google 로그인하면 관리자 페이지에 접속할 수 있습니다.",
+                "Event Bingo 이벤트 관리자 권한 신청이 승인되었습니다.",
+                "이제 승인된 이메일로 Google 로그인하면 이벤트 관리 페이지에 접속할 수 있습니다.",
                 "Gmail 주소가 아니어도 Google 계정에 연결된 이메일이면 사용할 수 있습니다.",
                 "",
                 console_url,

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -348,9 +348,9 @@ async def update_event_manager_request(
     return AdminEventManagerRequestResponse(
         ok=True,
         message=(
-            "신청을 승인했고 관리자 권한 안내 메일을 발송했습니다."
+            "신청을 승인했고 이벤트 관리자 권한 안내 메일을 발송했습니다."
             if payload.status == "approved" and invite_result and invite_result.invite_email_sent
-            else "신청을 승인했습니다. 승인된 이메일로 Google 로그인하면 관리자 페이지에 접속할 수 있습니다."
+            else "신청을 승인했습니다. 승인된 이메일로 Google 로그인하면 이벤트 관리 페이지에 접속할 수 있습니다."
             if payload.status == "approved" and invite_result
             else "이미 관리자 계정이 있어 신청 상태만 업데이트했습니다."
             if payload.status == "approved"

--- a/backend/app/tests/test_admin_console_services.py
+++ b/backend/app/tests/test_admin_console_services.py
@@ -136,9 +136,11 @@ def test_build_access_granted_email_sets_event_bingo_sender_and_reply_to(
 
     message = console_services._build_access_granted_email("운영자", "https://example.com/admin")
 
-    assert message["Subject"] == "[Event Bingo] 관리자 권한이 승인되었습니다"
+    assert message["Subject"] == "[Event Bingo] 이벤트 관리자 권한이 승인되었습니다"
     assert message["Reply-To"] == "devfactory.ops@gmail.com"
     assert "DevFactory 운영팀입니다." in message.get_content()
+    assert "Event Bingo 이벤트 관리자 권한 신청이 승인되었습니다." in message.get_content()
+    assert "이벤트 관리 페이지에 접속할 수 있습니다." in message.get_content()
     assert "devfactory.ops@gmail.com" in message.get_content()
 
 


### PR DESCRIPTION
## 작업 내용
- 승인 안내 메일 제목과 본문을 `관리자 권한`에서 `이벤트 관리자 권한`으로 정리했습니다.
- 승인 후 접속 안내를 `관리자 페이지` 대신 `이벤트 관리 페이지`로 조정했습니다.
- 승인 API 응답 문구도 동일한 권한 표현으로 맞췄습니다.

## 검증
- `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests/test_admin_console_services.py app/tests/test_admin_routes.py`

## 참고
- 관련 이슈: #189
- 반려 메일 발송은 아직 구현되지 않았으므로 이 PR에서 #189를 닫지 않습니다.