### PR TITLE
[Admin] 참가자 없는 행사 삭제 기능 추가

### DIFF
--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -181,6 +181,10 @@ def can_manage_owner_scope(actor: Admin, event: Event) -> bool:
     return actor.role == AdminRole.ADMIN or actor.id == event.admin_id
 
 
+def can_delete_event(actor: Admin, event: Event, participant_count: int) -> bool:
+    return can_manage_owner_scope(actor, event) and participant_count == 0
+
+
 def build_visible_admin_events_query(actor: Admin):
     query = select(Event).order_by(Event.start_time.desc())
     if actor.role != AdminRole.ADMIN:
@@ -587,6 +591,7 @@ async def build_event_summary(
         progress_total=participant_count,
         status=resolve_event_status(event),
         can_edit=await can_edit_event(session, actor, event),
+        can_delete=can_delete_event(actor, event, participant_count),
     )
 
 
@@ -698,6 +703,7 @@ async def build_event_detail(
         progress_total=participant_count,
         status=resolve_event_status(event),
         can_edit=await can_edit_event(session, actor, event),
+        can_delete=can_delete_event(actor, event, participant_count),
     )
     return AdminEventDetail(
         **summary.model_dump(),
@@ -906,6 +912,28 @@ async def reset_event_runtime_data(
         "deleted_interactions": deleted_interactions,
         "skipped_shared_users": len(shared_user_id_set),
     }
+
+
+async def delete_empty_event(
+    session: AsyncSession,
+    event: Event,
+) -> None:
+    participant_count = await Event.get_participant_count(session, event.id)
+    if participant_count > 0:
+        raise ValueError("참가자가 없는 행사만 삭제할 수 있습니다.")
+
+    await session.execute(
+        delete(BingoInteraction).where(BingoInteraction.event_id == event.id)
+    )
+    await session.execute(delete(BingoBoards).where(BingoBoards.event_id == event.id))
+    await session.execute(delete(EventAttendee).where(EventAttendee.event_id == event.id))
+    await session.execute(delete(Team).where(Team.event_id == event.id))
+    await session.execute(delete(Room).where(Room.event_id == event.id))
+    await session.execute(delete(EventCoHost).where(EventCoHost.event_id == event.id))
+    await session.delete(event)
+    await session.commit()
+
+
 async def approve_event_manager_request(
     session: AsyncSession,
     request: EventManagerRequest,

--- a/backend/app/api/admin/routes.py
+++ b/backend/app/api/admin/routes.py
@@ -31,9 +31,10 @@ from .console_services import (
     build_event_detail,
     build_event_rooms,
     build_visible_admin_events_query,
-    can_edit_event,
+    can_delete_event,
     can_manage_owner_scope,
     can_view_event,
+    delete_empty_event,
     ensure_admin_console_seed_data,
     kick_event_attendee,
     normalize_event_keywords,
@@ -48,6 +49,7 @@ from .console_services import (
 )
 from .schema import (
     AdminEventDetailResponse,
+    AdminEventDeleteResponse,
     AdminEventListResponse,
     AdminEventManagerRequestListResponse,
     AdminEventManagerRequestResponse,
@@ -369,7 +371,7 @@ async def list_admin_events(
 ):
     from collections import defaultdict
     from .console_services import (
-        can_edit_event,
+        can_delete_event,
         resolve_event_status,
     )
     from .schema import AdminEventSummary
@@ -436,6 +438,7 @@ async def list_admin_events(
                 progress_total=participant_count,
                 status=resolve_event_status(event),
                 can_edit=can_manage_owner_scope(actor, event),
+                can_delete=can_delete_event(actor, event, participant_count),
             )
         )
 
@@ -553,6 +556,41 @@ async def update_admin_event(
         ok=True,
         message="이벤트를 수정했습니다.",
         event=await build_event_detail(db, updated_event, actor),
+    )
+
+
+@admin_router.delete(
+    "/events/{event_id}",
+    response_model=AdminEventDeleteResponse,
+    summary="빈 이벤트 삭제",
+)
+async def delete_admin_event(
+    event_id: int,
+    db: AsyncSessionDepends,
+    actor: Admin = Depends(authenticate_admin_session),
+):
+    try:
+        event = await Event.get_by_id(db, event_id)
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    participant_count = await Event.get_participant_count(db, event.id)
+    if not can_manage_owner_scope(actor, event):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="이 행사를 삭제할 권한이 없습니다.",
+        )
+    if not can_delete_event(actor, event, participant_count):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="참가자 데이터가 있는 행사는 먼저 데이터 초기화 후 삭제할 수 있습니다.",
+        )
+
+    await delete_empty_event(db, event)
+    return AdminEventDeleteResponse(
+        ok=True,
+        message="행사를 삭제했습니다.",
+        deleted_event_id=event_id,
     )
 
 

--- a/backend/app/api/admin/schema.py
+++ b/backend/app/api/admin/schema.py
@@ -153,6 +153,7 @@ class AdminEventSummary(BaseModel):
     progress_total: int
     status: EventStatusLiteral
     can_edit: bool
+    can_delete: bool
 
 
 class AdminEventDetail(AdminEventSummary):
@@ -226,3 +227,7 @@ class AdminEventResetStats(BaseModel):
 
 class AdminEventResetResponse(BaseSchema):
     stats: AdminEventResetStats = Field(default_factory=AdminEventResetStats)
+
+
+class AdminEventDeleteResponse(BaseSchema):
+    deleted_event_id: int

--- a/backend/app/tests/test_admin_routes.py
+++ b/backend/app/tests/test_admin_routes.py
@@ -6,7 +6,7 @@ from api.admin import auth as admin_auth
 import api.admin.routes as admin_routes
 from api.admin.routes import admin_router
 from models.admin import AdminRole
-from models.event import EventStatus, GameMode
+from models.event import Event, EventStatus, GameMode
 
 
 class _FakeScalarResult:
@@ -104,6 +104,7 @@ def test_list_admin_events_route_limits_event_manager_to_owned_events(monkeypatc
     assert [event.id for event in response.events] == [20]
     assert response.events[0].created_by_id == actor.id
     assert response.events[0].can_edit is True
+    assert response.events[0].can_delete is True
     assert response.events[0].expected_attendee_count == 100
     assert response.events[0].restrict_before_start is True
 
@@ -133,6 +134,7 @@ def test_list_admin_events_route_includes_co_host_events(monkeypatch):
     assert [event.id for event in response.events] == [30]
     assert response.events[0].created_by_id == 3
     assert response.events[0].can_edit is False
+    assert response.events[0].can_delete is False
 
 
 def test_list_admin_events_route_keeps_full_scope_for_admin(monkeypatch):
@@ -158,6 +160,109 @@ def test_list_admin_events_route_keeps_full_scope_for_admin(monkeypatch):
     assert response.ok is True
     assert [event.id for event in response.events] == [10, 20]
     assert all(event.can_edit for event in response.events)
+    assert [event.can_delete for event in response.events] == [True, True]
+
+
+def test_delete_admin_event_allows_owner_empty_event(monkeypatch):
+    actor = _admin_stub(2, AdminRole.EVENT_MANAGER)
+    event = _event_stub(20, 2, "삭제할 행사")
+    deleted = {}
+
+    async def fake_get_by_id(_db, event_id):
+        assert event_id == event.id
+        return event
+
+    async def fake_get_participant_count(_db, event_id):
+        assert event_id == event.id
+        return 0
+
+    async def fake_delete_empty_event(_db, target_event):
+        deleted["event_id"] = target_event.id
+
+    monkeypatch.setattr(Event, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(Event, "get_participant_count", fake_get_participant_count)
+    monkeypatch.setattr(admin_routes, "delete_empty_event", fake_delete_empty_event)
+
+    response = asyncio.run(admin_routes.delete_admin_event(event.id, object(), actor))
+
+    assert response.ok is True
+    assert response.deleted_event_id == event.id
+    assert deleted == {"event_id": event.id}
+
+
+def test_delete_admin_event_allows_admin_empty_event(monkeypatch):
+    actor = _admin_stub(1, AdminRole.ADMIN)
+    event = _event_stub(20, 2, "관리자 삭제 행사")
+    deleted = {}
+
+    async def fake_get_by_id(_db, event_id):
+        assert event_id == event.id
+        return event
+
+    async def fake_get_participant_count(_db, event_id):
+        assert event_id == event.id
+        return 0
+
+    async def fake_delete_empty_event(_db, target_event):
+        deleted["event_id"] = target_event.id
+
+    monkeypatch.setattr(Event, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(Event, "get_participant_count", fake_get_participant_count)
+    monkeypatch.setattr(admin_routes, "delete_empty_event", fake_delete_empty_event)
+
+    response = asyncio.run(admin_routes.delete_admin_event(event.id, object(), actor))
+
+    assert response.ok is True
+    assert response.deleted_event_id == event.id
+    assert deleted == {"event_id": event.id}
+
+
+def test_delete_admin_event_blocks_non_owner_event_manager(monkeypatch):
+    actor = _admin_stub(3, AdminRole.EVENT_MANAGER)
+    event = _event_stub(20, 2, "남의 행사")
+
+    async def fake_get_by_id(_db, event_id):
+        assert event_id == event.id
+        return event
+
+    async def fake_get_participant_count(_db, event_id):
+        assert event_id == event.id
+        return 0
+
+    monkeypatch.setattr(Event, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(Event, "get_participant_count", fake_get_participant_count)
+
+    try:
+        asyncio.run(admin_routes.delete_admin_event(event.id, object(), actor))
+    except admin_routes.HTTPException as error:
+        assert error.status_code == 403
+        assert "삭제할 권한" in error.detail
+    else:
+        raise AssertionError("Expected HTTPException")
+
+
+def test_delete_admin_event_blocks_event_with_participants(monkeypatch):
+    actor = _admin_stub(2, AdminRole.EVENT_MANAGER)
+    event = _event_stub(20, 2, "참가자 있는 행사")
+
+    async def fake_get_by_id(_db, event_id):
+        assert event_id == event.id
+        return event
+
+    async def fake_get_participant_count(_db, event_id):
+        assert event_id == event.id
+        return 1
+
+    monkeypatch.setattr(Event, "get_by_id", fake_get_by_id)
+    monkeypatch.setattr(Event, "get_participant_count", fake_get_participant_count)
+
+    try:
+        asyncio.run(admin_routes.delete_admin_event(event.id, object(), actor))
+    except admin_routes.HTTPException as error:
+        assert error.status_code == 400
+        assert "먼저 데이터 초기화" in error.detail
+    else:
+        raise AssertionError("Expected HTTPException")
 
 
 def test_fetch_supabase_user_payload_uses_supabase_auth_user(monkeypatch):

--- a/frontend/src/api/admin_api.ts
+++ b/frontend/src/api/admin_api.ts
@@ -153,6 +153,7 @@ type AdminEventPayload = {
   progress_total: number;
   status: EventStatusLiteral;
   can_edit: boolean;
+  can_delete: boolean;
   public_path?: string;
   participants?: AdminEventParticipantPayload[];
   analytics?: AdminEventAnalyticsPayload;
@@ -175,6 +176,10 @@ type AdminEventResetResponse = ApiResponseBase & {
     deleted_interactions: number;
     skipped_shared_users: number;
   } | null;
+};
+
+type AdminEventDeleteResponse = ApiResponseBase & {
+  deleted_event_id: number;
 };
 
 export type AdminEventUpsertInput = {
@@ -383,6 +388,7 @@ const mapAdminEvent = (payload: AdminEventPayload): AdminEvent => {
     progressTotal: payload.progress_total,
     status: payload.status,
     canEdit: payload.can_edit,
+    canDelete: payload.can_delete,
     publicPath: payload.public_path,
     participants: mapParticipants(payload.participants),
     analytics: mapAnalytics(payload.analytics),
@@ -598,6 +604,16 @@ export const resetAdminEventData = async (accessToken: string, eventId: number) 
     `/api/admin/events/${eventId}/reset-data`,
     {
       method: "POST",
+    },
+    accessToken
+  );
+};
+
+export const deleteAdminEvent = async (accessToken: string, eventId: number) => {
+  return requestJson<AdminEventDeleteResponse>(
+    `/api/admin/events/${eventId}`,
+    {
+      method: "DELETE",
     },
     accessToken
   );

--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -14,6 +14,7 @@ import {
   AdminApiError,
   createAdminEvent,
   createAdminMember,
+  deleteAdminEvent,
   deleteAdminMember,
   getAdminEventDetail,
   getAdminEventManagerRequests,
@@ -1135,6 +1136,7 @@ const AdminConsolePage = ({
     number | null
   >(null);
   const [resettingEventId, setResettingEventId] = useState<number | null>(null);
+  const [deletingEventId, setDeletingEventId] = useState<number | null>(null);
   const [newAdminForm, setNewAdminForm] = useState({
     email: "",
     name: "",
@@ -2048,6 +2050,39 @@ const AdminConsolePage = ({
       );
     } finally {
       setResettingEventId(null);
+    }
+  };
+
+  const handleDeleteSelectedEvent = async () => {
+    if (!session || !selectedEvent || !selectedEvent.canDelete) {
+      return;
+    }
+
+    const isConfirmed = window.confirm(
+      `"${selectedEvent.name}" 행사를 삭제할까요?\n행사 소유자는 참가자 데이터가 없는 행사만 삭제할 수 있으며, 이 작업은 되돌릴 수 없습니다.`,
+    );
+    if (!isConfirmed) {
+      return;
+    }
+
+    try {
+      setDeletingEventId(selectedEvent.id);
+      setPageError("");
+
+      await deleteAdminEvent(session.accessToken, selectedEvent.id);
+      setEvents((currentEvents) =>
+        currentEvents.filter((eventItem) => eventItem.id !== selectedEvent.id),
+      );
+      setSelectedEventDetail(null);
+      setPageNotice("행사를 삭제했습니다.");
+      navigate(getAdminPath("event-settings"), { replace: true });
+      contentScrollRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+    } catch (error) {
+      setPageError(
+        error instanceof Error ? error.message : "행사를 삭제하지 못했습니다.",
+      );
+    } finally {
+      setDeletingEventId(null);
     }
   };
 
@@ -2994,6 +3029,26 @@ const AdminConsolePage = ({
                                   {resettingEventId === selectedEvent.id
                                     ? "초기화 중"
                                     : "데이터 초기화"}
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  className="h-10 rounded-full border-rose-200 bg-white px-4 text-sm font-semibold text-rose-600 hover:bg-rose-50 hover:text-rose-700 disabled:border-slate-100 disabled:text-slate-300"
+                                  disabled={
+                                    !selectedEvent.canDelete ||
+                                    deletingEventId === selectedEvent.id
+                                  }
+                                  title={
+                                    selectedEvent.canDelete
+                                      ? "참가자가 없는 행사를 삭제합니다."
+                                      : "참가자 데이터가 있는 행사는 데이터 초기화 후 삭제할 수 있습니다."
+                                  }
+                                  onClick={() =>
+                                    void handleDeleteSelectedEvent()
+                                  }
+                                >
+                                  {deletingEventId === selectedEvent.id
+                                    ? "삭제 중"
+                                    : "행사 삭제"}
                                 </Button>
                               </>
                             ) : null}

--- a/frontend/src/modules/Admin/adminDashboardUtils.test.ts
+++ b/frontend/src/modules/Admin/adminDashboardUtils.test.ts
@@ -29,6 +29,7 @@ const makeEvent = (overrides: Partial<AdminEvent>): AdminEvent => ({
   progressTotal: 0,
   status: "scheduled",
   canEdit: true,
+  canDelete: true,
   ...overrides,
 });
 

--- a/frontend/src/modules/Admin/adminTypes.ts
+++ b/frontend/src/modules/Admin/adminTypes.ts
@@ -107,6 +107,7 @@ export type AdminEvent = {
   progressTotal: number;
   status: AdminEventStatus;
   canEdit: boolean;
+  canDelete: boolean;
   publicPath?: string;
   participants?: AdminEventParticipant[];
   analytics?: AdminEventAnalytics;


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: #241
- Closes #241

## Impact Trigger (Select At Least One)
- [x] Cross-domain change (BE/FE/Infra)
- [x] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [x] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [x] docs/reference/design-guide.md (if applicable)
- [ ] docs/reference/agent-collaboration.md

## Changes
- Admin 이벤트 요약/상세 응답에 `can_delete`를 추가했습니다.
- `DELETE /api/admin/events/{event_id}`를 추가했습니다.
- 서비스 관리자(Admin) 또는 행사 소유자는 참가자 데이터가 없는 행사만 삭제할 수 있습니다.
- 참가자 데이터가 있는 행사는 삭제하지 못하고, 먼저 데이터 초기화가 필요하다는 에러를 반환합니다.
- 삭제 시 빈 행사에 연결된 interaction, board, attendee, team, room, co-host 데이터를 정리합니다.
- 관리자 상세 화면에 `행사 삭제` 버튼을 추가했습니다.
- 참가자 데이터가 있는 행사는 삭제 버튼을 비활성화하고, 데이터 초기화 후 삭제할 수 있다는 안내를 title로 제공합니다.
- 행사 매니저에게 보이는 확인 문구는 내부 권한명 `Admin` 대신 `행사 소유자` 기준으로 정리했습니다.

## Validation
- Tests:
  - `PYTHONPATH=app /tmp/event-bingo-backend-venv/bin/pytest app/tests/test_admin_routes.py app/tests/test_admin_console_services.py`
  - `npm run lint`
  - `npm run test`
  - `npm run build`
  - `git diff --check`
- Result:
  - Backend: 41 passed, 1 warning
  - Frontend tests: 18 files passed, 84 tests passed
  - Frontend lint/build passed
  - diff whitespace check passed
  - Vite build에서 기존 chunk size warning이 표시됩니다.
- Not run and reason:
  - 실제 관리자 Google 로그인 기반 수동 삭제 플로우는 로컬 자동화로 실행하지 않았습니다.

## Guide Sync Check
- [ ] Updated Korean mirrors for changed English guides
  - No source-of-truth guide was changed in this PR.

## Handoff
- [x] Added handoff note following docs/templates/agent-handoff.md

### Task Metadata
- Task ID: #241

### Scope
- In scope: 참가자 데이터가 없는 행사 삭제 API/UI, Admin/행사 소유자 권한, 관련 테스트
- Out of scope: 참가자 데이터가 있는 행사 직접 삭제, soft delete/archive, co-host 권한 관리 UI

### Workspace
- Worktree path: `/home/ubuntu/.openclaw/workspace-df/event-bingo-admin-event-delete`
- Branch: `feat/admin-empty-event-delete`
- Base: `origin/main` (`185e92d`)

### Inputs Used
- Source docs: `docs/reference/design-guide.md`
- Additional constraints: #240 머지 후 삭제 작업을 별도 PR로 분리

### Changes Made
- Files changed: `backend/app/api/admin/**`, `backend/app/tests/test_admin_routes.py`, `frontend/src/api/admin_api.ts`, `frontend/src/modules/Admin/**`
- Behavior changes: 빈 행사만 삭제 가능, 참가자 데이터가 있으면 데이터 초기화 후 삭제 필요

### Validation
- Tests run: 위 Validation 섹션 참조
- Results: 위 Validation 섹션 참조
- Not run and reason: 관리자 인증이 필요한 실제 수동 삭제 플로우는 자동화하지 않음

### Risks
- Known risks: 삭제는 되돌릴 수 없는 작업이므로 preview에서 버튼 활성/비활성 조건과 확인 문구를 수동 확인해야 합니다.
- Follow-up needed: 장기적으로 행사 보관/비활성화가 필요하면 soft delete/archive 이슈로 별도 설계합니다.

### Next Owner
- Owner: FE/BE reviewer, QA
- Expected next action: 참가자 0명 행사 삭제, 참가자 있는 행사에서 삭제 버튼 비활성화, 데이터 초기화 후 삭제 가능 여부를 확인합니다.
