### PR TITLE
관리자 계정 생성일/전화번호 메타데이터 정리

### DIFF
--- a/backend/app/api/admin/console_services.py
+++ b/backend/app/api/admin/console_services.py
@@ -44,7 +44,6 @@ from .schema import (
 )
 
 
-DEFAULT_ADMIN_PHONE = "010-0000-0000"
 KST = ZoneInfo("Asia/Seoul")
 PERSONAL_DATA_RETENTION_DAYS = max(1, int(os.getenv("PRIVACY_PERSONAL_DATA_RETENTION_DAYS", "365")))
 PRIVACY_REDACTION_RUN_ON_STARTUP = (
@@ -137,7 +136,6 @@ def serialize_admin_member(admin: Admin) -> AdminMemberItem:
         id=admin.id,
         email=admin.email,
         name=admin.name,
-        phone=DEFAULT_ADMIN_PHONE,
         created_at=admin.created_at,
         role=admin.role.value,
     )

--- a/backend/app/api/admin/schema.py
+++ b/backend/app/api/admin/schema.py
@@ -27,7 +27,6 @@ class AdminMemberItem(BaseModel):
     id: int
     email: str
     name: str
-    phone: str
     created_at: datetime
     role: AdminRoleLiteral
 

--- a/backend/app/migrations/versions/e4f5a6b7c8d9_normalize_admin_timestamps_to_kst.py
+++ b/backend/app/migrations/versions/e4f5a6b7c8d9_normalize_admin_timestamps_to_kst.py
@@ -1,0 +1,39 @@
+"""normalize admin timestamps to kst
+
+Revision ID: e4f5a6b7c8d9
+Revises: d2f4a8c9b1e3
+Create Date: 2026-06-07 07:15:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "e4f5a6b7c8d9"
+down_revision: Union[str, None] = "d2f4a8c9b1e3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE admins
+        SET
+            created_at = created_at + INTERVAL '9 hours',
+            updated_at = updated_at + INTERVAL '9 hours'
+        WHERE created_at IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE admins
+        SET
+            created_at = created_at - INTERVAL '9 hours',
+            updated_at = updated_at - INTERVAL '9 hours'
+        WHERE created_at IS NOT NULL
+        """
+    )

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from typing import Optional
 import enum
 
@@ -7,6 +8,12 @@ from sqlalchemy.orm import Mapped, mapped_column
 from core.db import AsyncSession
 from models.base import Base
 import bcrypt
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def now_kst_naive() -> datetime:
+    return datetime.now(KST).replace(tzinfo=None)
 
 
 class AdminRole(enum.Enum):
@@ -27,11 +34,11 @@ class Admin(Base):
     invite_token_expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     invitation_sent_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        default=datetime.now, nullable=False
+        default=now_kst_naive, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        default=datetime.now,
-        onupdate=datetime.now,
+        default=now_kst_naive,
+        onupdate=now_kst_naive,
         nullable=False,
     )
 

--- a/backend/app/tests/test_admin_console_services.py
+++ b/backend/app/tests/test_admin_console_services.py
@@ -1,5 +1,7 @@
 import asyncio
 from collections import Counter
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
 
 import api.admin.console_services as console_services
 import pytest
@@ -20,12 +22,13 @@ from api.admin.console_services import (
     resolve_participant_name,
     resolve_selected_keywords,
     resolve_personal_data_cutoff,
+    serialize_admin_member,
     validate_admin_member_deletion,
     validate_event_manager_request_transition,
     validate_event_schedule,
 )
 from datetime import datetime, timedelta, timezone
-from models.admin import AdminRole
+from models.admin import AdminRole, now_kst_naive
 from models.event_manager_request import EventManagerRequestStatus
 
 
@@ -60,6 +63,34 @@ def test_filter_visible_admin_events_limits_event_manager_to_owned_events():
     other_event = type("EventStub", (), {"id": 30, "admin_id": 3})()
 
     assert filter_visible_admin_events(actor, [owned_event, other_event]) == [owned_event]
+
+
+def test_now_kst_naive_uses_kst_wall_clock():
+    actual = now_kst_naive()
+    expected = datetime.now(ZoneInfo("Asia/Seoul")).replace(tzinfo=None)
+
+    assert actual.tzinfo is None
+    assert abs((actual - expected).total_seconds()) < 2
+
+
+def test_serialize_admin_member_omits_unconnected_phone():
+    admin = SimpleNamespace(
+        id=7,
+        email="manager@example.com",
+        name="행사 매니저",
+        created_at=datetime(2026, 6, 7, 15, 30),
+        role=AdminRole.EVENT_MANAGER,
+    )
+
+    item = serialize_admin_member(admin)
+    data = item.model_dump()
+
+    assert data["id"] == 7
+    assert data["email"] == "manager@example.com"
+    assert data["name"] == "행사 매니저"
+    assert data["created_at"] == datetime(2026, 6, 7, 15, 30)
+    assert data["role"] == "event_manager"
+    assert "phone" not in data
 
 
 def test_can_manage_owner_scope_allows_admin_and_owner_only():

--- a/docs/handoffs/2026-06-07-admin-member-metadata.md
+++ b/docs/handoffs/2026-06-07-admin-member-metadata.md
@@ -1,0 +1,69 @@
+# Admin Member Metadata Handoff
+
+## Task Metadata
+- Task ID: 관리자 계정 생성일 KST 정리 및 더미 전화번호 제거
+
+## Scope
+- In scope:
+  - 관리자 계정 목록 API 응답에서 실제 데이터가 없는 `phone` 필드 제거
+  - 관리자 계정 목록 UI의 전화번호 컬럼 제거
+  - 관리자 계정 `created_at`/`updated_at` 기본값을 KST wall-clock 기준으로 변경
+  - 기존 관리자 계정 timestamp를 UTC wall-clock에서 KST wall-clock으로 보정하는 migration 추가
+- Out of scope:
+  - 행사 매니저 신청서에 전화번호 입력 추가
+  - 개인정보 수집 항목 확대
+  - 운영 알림/이메일 내용 변경
+
+## Workspace
+- Worktree path: `/home/ubuntu/.openclaw/workspace-df/event-bingo`
+- Branch: `fix/admin-member-created-at-phone`
+- Base: `main`
+
+## Inputs Used
+- Source docs:
+  - `AGENTS.md`
+- Additional constraints:
+  - API 응답과 DB migration을 함께 바꾸므로 PR 대상입니다.
+  - root workspace의 untracked `image.png`는 기존 파일로 보고 건드리지 않았습니다.
+
+## Changes Made
+- Files changed:
+  - `backend/app/api/admin/schema.py`
+  - `backend/app/api/admin/console_services.py`
+  - `backend/app/models/admin.py`
+  - `backend/app/migrations/versions/e4f5a6b7c8d9_normalize_admin_timestamps_to_kst.py`
+  - `backend/app/tests/test_admin_console_services.py`
+  - `frontend/src/api/admin_api.ts`
+  - `frontend/src/modules/Admin/AdminPortal.tsx`
+  - `frontend/src/modules/Admin/adminTypes.ts`
+  - `frontend/e2e/support/adminApi.ts`
+- Behavior changes:
+  - 관리자 계정 목록에서 전화번호가 더 이상 표시되지 않습니다.
+  - 새 관리자 계정의 생성/수정 시각은 KST wall-clock으로 저장됩니다.
+  - migration 적용 시 기존 관리자 계정의 생성/수정 시각에 9시간을 더해 KST 표시와 맞춥니다.
+
+## Validation
+- Tests run:
+  - `npm run lint`
+  - `npm test`
+  - `npm run build`
+  - `docker exec event-bingo-backend-1 sh -lc 'cd /app && PYTHONPATH=/app/app python -m pytest app/tests/test_admin_console_services.py'`
+  - `docker exec event-bingo-backend-1 sh -lc 'cd /app && PYTHONPATH=/app/app alembic heads'`
+  - `docker exec event-bingo-backend-1 sh -lc 'cd /app && PYTHONPATH=/app/app alembic current'`
+- Results:
+  - Frontend lint/test/build passed.
+  - Backend admin console service tests passed.
+  - Alembic head/current is `e4f5a6b7c8d9`.
+- Not run and reason:
+  - Full E2E was not run; changed UI is limited to admin member list metadata and covered by type/build checks.
+
+## Risks
+- Known risks:
+  - 기존 관리자 timestamp가 이미 수동으로 KST 보정된 환경이 있다면 migration이 9시간을 한 번 더 더할 수 있습니다.
+  - 현재 코드/런타임 기준으로는 기존 값이 UTC wall-clock으로 저장된 가능성이 높아 보정 migration을 포함했습니다.
+- Follow-up needed:
+  - 전화번호 수집이 실제로 필요해지면 신청서, API, DB, 개인정보 안내를 별도 PR로 확장해야 합니다.
+
+## Next Owner
+- Owner: FE/BE reviewer
+- Expected next action: PR 리뷰 후 운영 배포 시 Alembic migration 적용 확인

--- a/frontend/e2e/support/adminApi.ts
+++ b/frontend/e2e/support/adminApi.ts
@@ -148,7 +148,6 @@ export const mockAdminBootstrapRoutes = async ({
           id: session.id,
           email: session.email,
           name: session.name,
-          phone: "010-0000-0000",
           created_at: "2026-03-28T10:00:00+09:00",
           role: session.role,
         },

--- a/frontend/src/api/admin_api.ts
+++ b/frontend/src/api/admin_api.ts
@@ -46,7 +46,6 @@ type AdminMemberPayload = {
   id: number;
   email: string;
   name: string;
-  phone: string;
   created_at: string;
   role: AdminRoleLiteral;
 };
@@ -283,7 +282,6 @@ const mapAdminMember = (payload: AdminMemberPayload): AdminMember => {
     id: payload.id,
     email: payload.email,
     name: payload.name,
-    phone: payload.phone,
     createdAt: payload.created_at,
     role: payload.role,
   };

--- a/frontend/src/modules/Admin/AdminPortal.tsx
+++ b/frontend/src/modules/Admin/AdminPortal.tsx
@@ -2753,13 +2753,12 @@ const AdminConsolePage = ({
 
                   <div className="overflow-hidden rounded-[1.6rem] border border-slate-100 bg-[#fbfcf8]">
                     <div className="overflow-x-auto">
-                      <Table className="min-w-[760px]">
+                      <Table className="min-w-[680px]">
                         <TableHeader className="bg-[#f6f8ef]">
                           <TableRow className="border-none hover:bg-transparent">
                             <TableHead>번호</TableHead>
                             <TableHead>이름</TableHead>
                             <TableHead>계정</TableHead>
-                            <TableHead>전화번호</TableHead>
                             <TableHead>생성일</TableHead>
                             <TableHead>권한</TableHead>
                             <TableHead className="text-left">관리</TableHead>
@@ -2775,7 +2774,6 @@ const AdminConsolePage = ({
                                 {member.name}
                               </TableCell>
                               <TableCell>{member.email}</TableCell>
-                              <TableCell>{member.phone}</TableCell>
                               <TableCell>
                                 {formatAdminDate(member.createdAt)}
                               </TableCell>

--- a/frontend/src/modules/Admin/adminTypes.ts
+++ b/frontend/src/modules/Admin/adminTypes.ts
@@ -5,7 +5,6 @@ export type AdminMember = {
   id: number;
   email: string;
   name: string;
-  phone: string;
   createdAt: string;
   role: AdminRole;
 };


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: 관리자 계정 생성일 KST 정리 및 더미 전화번호 제거

## Impact Trigger (Select At Least One)
- [x] Cross-domain change (BE/FE/Infra)
- [x] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [x] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [x] docs/reference/agent-collaboration.md

## Changes
- 관리자 계정 API 응답에서 실제 데이터가 없는 `phone` 필드를 제거했습니다.
- 관리자 계정 목록 UI에서 전화번호 컬럼을 제거했습니다.
- 관리자 계정 `created_at`/`updated_at` 기본값을 KST wall-clock 기준으로 변경했습니다.
- 기존 관리자 timestamp를 KST wall-clock으로 보정하는 Alembic migration을 추가했습니다.
- impact 작업 handoff 문서를 추가했습니다.

## Validation
- Tests:
  - `npm run lint`
  - `npm test`
  - `npm run build`
  - `docker exec event-bingo-backend-1 sh -lc 'cd /app && PYTHONPATH=/app/app python -m pytest app/tests/test_admin_console_services.py'`
  - `docker exec event-bingo-backend-1 sh -lc 'cd /app && PYTHONPATH=/app/app alembic heads'`
  - `docker exec event-bingo-backend-1 sh -lc 'cd /app && PYTHONPATH=/app/app alembic current'`
- Result:
  - Frontend lint/test/build 통과
  - Backend admin console service 테스트 통과
  - Alembic head/current `e4f5a6b7c8d9` 확인
- Not run and reason:
  - 전체 E2E는 실행하지 않았습니다. 변경 UI는 관리자 계정 목록 메타데이터 컬럼 제거에 한정되어 타입/빌드와 admin API mock 갱신으로 확인했습니다.

## Guide Sync Check
- [x] Source-of-truth guide 변경 없음. Korean mirror sync 불필요.

## Handoff
- [x] Added handoff note following docs/templates/agent-handoff.md
  - `docs/handoffs/2026-06-07-admin-member-metadata.md`
