### PR TITLE
프론트 E2E 전체 검증을 CI에 반영

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
   frontend-e2e:
-    name: Frontend E2E Smoke
+    name: Frontend E2E
     runs-on: ubuntu-latest
     needs: frontend
     defaults:
@@ -70,8 +70,8 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Public smoke tests
-        run: npm run e2e -- landing-page.spec.ts home.smoke.spec.ts public-entrypoints.smoke.spec.ts
+      - name: Playwright E2E tests
+        run: npm run e2e
 
       - name: Upload Playwright report
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Last-Validated: 2026-06-07
 - Prefer `CSS Grid` plus `SVG` overlays for bingo board layout and completed-line rendering rather than canvas-heavy implementations.
 - Document API contract deltas for frontend and QA handoff.
 - Add or update tests for each behavior change.
+- When frontend behavior, admin UI, game flow, or E2E support fixtures change, run the relevant frontend unit tests and the full Playwright E2E suite before treating the change as verified. If full E2E cannot be run, explicitly report the skipped specs and why; do not treat CI public smoke coverage as full frontend regression coverage.
 - Track and verify regression around issue #81 behavior.
 
 ## Definition Of Done

--- a/docs/handoffs/2026-06-07-frontend-e2e-coverage.md
+++ b/docs/handoffs/2026-06-07-frontend-e2e-coverage.md
@@ -1,0 +1,73 @@
+# Agent Handoff
+
+## Task Metadata
+- Task ID: frontend-e2e-coverage-audit-follow-up
+
+## Scope
+- In scope:
+  - Fix full Playwright E2E failures found during the test audit.
+  - Keep the event entry countdown flow locked until the public event profile is ready and the configured start time has passed.
+  - Update E2E fixtures for 4x4 board defaults and explicit before-start entry restriction.
+  - Run the full frontend Playwright suite in CI instead of only public smoke specs.
+  - Add a lightweight AGENTS rule requiring full E2E verification for frontend behavior, admin UI, game flow, or E2E fixture changes.
+- Out of scope:
+  - Switching Playwright from Vite dev server to production preview.
+  - Backend pytest dependency cleanup.
+  - Adding React component-level tests for admin screens.
+
+## Workspace
+- Worktree path: `/home/ubuntu/.openclaw/workspace-df/event-bingo`
+- Branch: `chore/full-e2e-ci-coverage`
+- Base: `main` at `0ad3eab`
+
+## Inputs Used
+- Source docs:
+  - `AGENTS.md`
+  - `.github/PULL_REQUEST_TEMPLATE.md`
+- Additional constraints:
+  - CI/CD workflow changes require PR review.
+  - PR title and body should be Korean.
+
+## Changes Made
+- Files changed:
+  - `.github/workflows/ci.yaml`
+  - `AGENTS.md`
+  - `frontend/src/modules/Bingo/BingoGame.tsx`
+  - `frontend/e2e/admin-event-settings.spec.ts`
+  - `frontend/e2e/auth-and-setup.spec.ts`
+  - `frontend/e2e/support/adminApi.ts`
+  - `frontend/e2e/support/bingoApi.ts`
+- Behavior changes:
+  - Event bingo entry now rechecks the current public event profile before bootstrapping the board. If before-start entry restriction is enabled and the event has not started, it stays on the countdown screen and bootstraps after unlock.
+  - Admin event E2E fixtures now support 4x4 board payloads.
+  - CI frontend E2E job now runs `npm run e2e` for all Playwright specs.
+
+## Validation
+- Tests run:
+  - `npm test`
+  - `npm run lint`
+  - `npm run build`
+  - `npm run e2e -- auth-and-setup.spec.ts`
+  - `npm run e2e`
+- Results:
+  - Frontend unit tests: 22 files, 94 tests passed.
+  - Lint passed.
+  - Build passed with the existing large chunk warning.
+  - Targeted auth/setup E2E passed.
+  - Full Playwright E2E passed: 14 tests.
+- Not run and reason:
+  - Backend tests were not rerun because this change does not touch backend code.
+
+## Risks
+- Known risks:
+  - Full E2E will increase CI runtime compared with the previous public smoke-only job.
+  - Playwright still runs against the Vite dev server, not a production preview build.
+- Follow-up needed:
+  - Consider switching Playwright CI to build plus `vite preview`.
+  - Consider adding admin React component tests for UI-heavy changes.
+
+## Next Owner
+- Owner: Frontend / QA
+- Expected next action:
+  - Review PR and confirm CI runtime is acceptable.
+  - Merge after CI passes.

--- a/frontend/e2e/admin-event-settings.spec.ts
+++ b/frontend/e2e/admin-event-settings.spec.ts
@@ -19,6 +19,7 @@ const existingEvent = buildAdminEventPayload({
   id: 101,
   slug: "existing-event",
   name: "기존 행사",
+  boardSize: 5,
   adminEmail: session.email,
 });
 
@@ -51,11 +52,12 @@ test("opens event modal and imports keywords from an existing event", async ({ p
 
     if (method === "POST") {
       createRequestBody = route.request().postDataJSON() as Record<string, unknown>;
+      const createdBoardSize = Number(createRequestBody.board_size);
       const createdEvent = buildAdminEventPayload({
         id: 202,
         slug: "new-token-2026",
         name: String(createRequestBody.name),
-        boardSize: Number(createRequestBody.board_size) === 3 ? 3 : 5,
+        boardSize: [3, 4, 5].includes(createdBoardSize) ? (createdBoardSize as 3 | 4 | 5) : 4,
         bingoMissionCount: Number(createRequestBody.bingo_mission_count),
         keywords: ((createRequestBody.keywords as string[]) ?? []).slice(),
         startAt: String(createRequestBody.start_at),
@@ -118,6 +120,7 @@ test("opens event modal and imports keywords from an existing event", async ({ p
 
   expect(createRequestBody).not.toBeNull();
   expect(createRequestBody?.slug).toBeUndefined();
-  expect(createRequestBody?.keywords).toHaveLength(25);
+  expect(createRequestBody?.board_size).toBe(4);
+  expect(createRequestBody?.keywords).toHaveLength(16);
   await expect(page).toHaveURL(/\/admin\/events\/202$/);
 });

--- a/frontend/e2e/auth-and-setup.spec.ts
+++ b/frontend/e2e/auth-and-setup.spec.ts
@@ -60,10 +60,14 @@ test("opens name setup first and completes initial keyword setup", async ({ page
 });
 
 test("opens name setup after waiting on the countdown screen", async ({ page }) => {
-  const startAt = new Date(Date.now() + 1000).toISOString();
+  const startAt = new Date(Date.now() + 2500).toISOString();
   const endAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
-  await mockPublicEventProfile(page, "bingo-networking", { startAt, endAt });
+  await mockPublicEventProfile(page, "bingo-networking", {
+    startAt,
+    endAt,
+    restrictBeforeStart: true,
+  });
   await seedBingoSession(page, {
     userId: 7,
     userName: "구글 닉네임",
@@ -74,5 +78,5 @@ test("opens name setup after waiting on the countdown screen", async ({ page }) 
   await page.goto("/event/bingo-networking/bingo");
 
   await expect(page.getByRole("heading", { name: "빙고 오픈까지 조금만 기다려 주세요" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "이름 설정" })).toBeVisible({ timeout: 4000 });
+  await expect(page.getByRole("heading", { name: "이름 설정" })).toBeVisible({ timeout: 8000 });
 });

--- a/frontend/e2e/support/adminApi.ts
+++ b/frontend/e2e/support/adminApi.ts
@@ -14,7 +14,7 @@ type AdminEventPayloadOptions = {
   id: number;
   slug: string;
   name: string;
-  boardSize?: 3 | 5;
+  boardSize?: 3 | 4 | 5;
   bingoMissionCount?: number;
   keywords?: string[];
   publishState?: "draft" | "published" | "archived";

--- a/frontend/e2e/support/bingoApi.ts
+++ b/frontend/e2e/support/bingoApi.ts
@@ -62,10 +62,13 @@ export const mockPublicEventProfile = async (
   options: {
     startAt?: string;
     endAt?: string;
+    boardSize?: 3 | 4 | 5;
+    restrictBeforeStart?: boolean;
   } = {}
 ) => {
   const startAt = options.startAt ?? new Date(Date.now() - 60 * 60 * 1000).toISOString();
   const endAt = options.endAt ?? new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const boardSize = options.boardSize ?? 5;
 
   await page.route(`**/api/events/${eventSlug}`, async (route) => {
     await fulfillJson(route, {
@@ -76,12 +79,13 @@ export const mockPublicEventProfile = async (
         slug: eventSlug,
         name: "Bingo Networking Event",
         location: "서울 컨벤션 센터",
-      event_team: "행사 운영팀",
+        event_team: "행사 운영팀",
         start_at: startAt,
         end_at: endAt,
-        board_size: 5,
+        board_size: boardSize,
         bingo_mission_count: 3,
-        keywords: Array.from({ length: 25 }, (_, index) => `키워드 ${index + 1}`),
+        restrict_before_start: options.restrictBeforeStart ?? false,
+        keywords: Array.from({ length: boardSize * boardSize }, (_, index) => `키워드 ${index + 1}`),
       },
     });
   });
@@ -94,7 +98,7 @@ export const mockPublicEventCatalog = async (
     slug: string;
     name: string;
     startAt: string;
-    boardSize: 3 | 5;
+    boardSize: 3 | 4 | 5;
     bingoMissionCount: number;
     status: "scheduled" | "in_progress" | "ended";
   }>

--- a/frontend/src/modules/Bingo/BingoGame.tsx
+++ b/frontend/src/modules/Bingo/BingoGame.tsx
@@ -507,7 +507,14 @@ const BingoGame = () => {
       }
 
       // 빙고 오픈 전이면 카운트다운만 표시 (API 호출 안 함)
-      if (locked) {
+      const now = new Date().getTime();
+      const isEntryLockedNow =
+        eventProfile.restrictBeforeStart &&
+        !testModeEnabled &&
+        (locked || now < unlockTime);
+      if (isEntryLockedNow) {
+        setLocked(true);
+        setRemainingTime(Math.max(0, unlockTime - now));
         setIsBootstrapping(false);
         return;
       }
@@ -607,10 +614,12 @@ const BingoGame = () => {
   }, [
     boardCellCount,
     cellValues,
+    eventProfile.restrictBeforeStart,
     eventHomePath,
     eventSlug,
     isEventProfileAvailable,
     locked,
+    unlockTime,
     navigate,
     showAlert,
     syncSessionDisplayName,


### PR DESCRIPTION
## Use This Template When
- This PR is for an impact change that should not be direct-pushed to `main`.

## Summary
- Task ID: 테스트 전수점검 후속
- 프론트 전체 E2E가 CI에서 빠져 있던 구멍을 막고, 전수 점검 중 발견된 E2E/카운트다운 문제를 함께 수정합니다.

## Impact Trigger (Select At Least One)
- [x] Cross-domain change (BE/FE/Infra)
- [ ] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [x] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [ ] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [x] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [ ] docs/reference/agent-collaboration.md
- 참고: 이번 변경은 reference 문서가 아니라 `AGENTS.md`와 handoff 문서만 갱신했습니다.

## Changes
- CI의 `frontend-e2e` job을 public smoke 3개 spec만 실행하던 방식에서 `npm run e2e` 전체 실행으로 변경했습니다.
- 시작 전 참가 제한이 켜진 행사에서 public event profile 로드 직후 이름 설정으로 먼저 진입할 수 있던 카운트다운 bootstrap 문제를 수정했습니다.
- E2E fixture가 4x4 보드와 `restrict_before_start`를 명시적으로 다룰 수 있게 정리했습니다.
- 관리자 행사 생성 E2E 기대값을 현재 기본값인 4x4, 16개 키워드 기준으로 수정했습니다.
- 프론트 동작/admin UI/game flow/E2E fixture 변경 시 full Playwright E2E 검증을 요구하는 AGENTS 룰을 추가했습니다.
- impact PR handoff 문서를 추가했습니다: `docs/handoffs/2026-06-07-frontend-e2e-coverage.md`

## Validation
- Tests:
  - `npm test`
  - `npm run lint`
  - `npm run build`
  - `npm run e2e -- auth-and-setup.spec.ts`
  - `npm run e2e`
- Result:
  - Frontend unit: 22 files, 94 tests passed
  - Lint passed
  - Build passed, 기존 large chunk warning은 유지
  - Targeted auth/setup E2E passed
  - Full Playwright E2E passed: 14 tests
- Not run and reason:
  - Backend tests: backend 코드를 변경하지 않아 미실행

## Guide Sync Check
- [x] Updated Korean mirrors for changed English guides
- 해당 없음: `docs/reference/*.md` 문서를 수정하지 않았습니다.

## Handoff
- [x] Added handoff note following docs/templates/agent-handoff.md