### PR TITLE
fix: 이벤트 트래픽 DB 연결 고갈 및 요청 증폭 완화

### DIFF
--- a/backend/app/api/auth/routes.py
+++ b/backend/app/api/auth/routes.py
@@ -55,7 +55,7 @@ async def bingo_login(
 
 @auth_router.get("/bingo/search", response_model=BingoParticipantSearchResult, description="빙고 참가자 이름 검색 API")
 async def bingo_search_participants(
-    q: str = Query(..., min_length=1, max_length=100, description="검색할 이름"),
+    q: str = Query(..., min_length=2, max_length=100, description="검색할 이름"),
     event_slug: str = Query(..., min_length=1, max_length=100, description="이벤트 slug"),
     exclude_user_id: int | None = Query(None, ge=1, description="검색 결과에서 제외할 유저 ID"),
     session: AsyncSessionDepends = None,

--- a/backend/app/config/.env.example
+++ b/backend/app/config/.env.example
@@ -4,6 +4,10 @@ ENV=development
 # DB (Supabase PostgreSQL - Transaction pooler)
 DB_URL=postgresql+asyncpg://postgres.[project-ref]:[password]@aws-1-ap-southeast-2.pooler.supabase.com:6543/postgres
 TEST_DB_URL=postgresql+asyncpg://event_bingo_test:event_bingo_test@127.0.0.1:55432/event_bingo_test
+# Per-process pool capacity. Maximum clients = replicas * workers * (pool size + overflow).
+DB_POOL_SIZE=3
+DB_MAX_OVERFLOW=1
+DB_POOL_TIMEOUT_SECONDS=5
 
 # Swagger docs auth
 SWAGGER_USERNAME=change-me-swagger-user

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,18 +1,13 @@
 import os
-from asyncio import current_task
-from core.log import logger
 from typing import Annotated, AsyncIterator
 from urllib.parse import urlparse
 from uuid import uuid4
 from fastapi import Depends
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
-    async_scoped_session,
     AsyncSession,
 )
-from sqlalchemy.pool import NullPool
 
 from dotenv import load_dotenv
 from models.base import Base
@@ -21,6 +16,26 @@ load_dotenv("config/.env", override=True)
 
 
 LOCAL_TEST_DB_HOSTS = {"localhost", "127.0.0.1", "::1", "postgres-test"}
+
+
+def calculate_max_pool_clients(replicas: int, workers: int, pool_size: int, max_overflow: int) -> int:
+    """Return the application-side connection ceiling across all worker processes."""
+    return replicas * workers * (pool_size + max_overflow)
+
+
+def _read_non_negative_int(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer.") from exc
+
+    if value < 0:
+        raise ValueError(f"{name} must be zero or greater.")
+    return value
 
 
 def assert_safe_test_database_url(db_url: str | None = None) -> None:
@@ -42,14 +57,16 @@ class Database:
     def __init__(self):
         self.async_engine = None
         self.async_session_factory = None
-        self.async_scoped_session = None
 
     def initialize(self):
         self.async_engine = create_async_engine(
             os.getenv("DB_URL"),
-            poolclass=NullPool,
+            pool_size=_read_non_negative_int("DB_POOL_SIZE", 3),
+            max_overflow=_read_non_negative_int("DB_MAX_OVERFLOW", 1),
+            pool_timeout=_read_non_negative_int("DB_POOL_TIMEOUT_SECONDS", 5),
             pool_pre_ping=True,
             pool_recycle=300,
+            pool_use_lifo=True,
             connect_args={
                 # Supabase pooler / PgBouncer uses transaction pooling, so
                 # asyncpg statement names must stay unique and unpooled.
@@ -61,7 +78,10 @@ class Database:
         self.async_session_factory = async_sessionmaker(
             bind=self.async_engine, autoflush=False, future=True, expire_on_commit=False, class_=AsyncSession
         )
-        self.async_scoped_session = async_scoped_session(self.async_session_factory, scopefunc=current_task)
+
+    async def dispose(self) -> None:
+        if self.async_engine is not None:
+            await self.async_engine.dispose()
 
     async def create_database(self) -> None:
         if os.getenv("ENV") != "test":
@@ -78,15 +98,16 @@ class Database:
             await conn.run_sync(Base.metadata.create_all)
 
     async def get_session(self) -> AsyncIterator[AsyncSession]:
-        async with self.async_scoped_session() as session:
+        if self.async_session_factory is None:
+            raise RuntimeError("Database has not been initialized.")
+
+        async with self.async_session_factory() as session:
             try:
                 yield session
                 await session.commit()
-            except SQLAlchemyError as e:
-                logger.error(e)
+            except Exception:
                 await session.rollback()
-            finally:
-                await session.close()
+                raise
 
 
 db = Database()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,13 +23,16 @@ from prometheus_fastapi_instrumentator import Instrumentator
 async def lifespan(app: FastAPI):
     # 서버 시작 전 초기화 단계 작성
     db.initialize()
-    await db.create_database()
-    async with db.async_session_factory() as session:
-        await ensure_admin_console_seed_data(session)
-        if PRIVACY_REDACTION_RUN_ON_STARTUP:
-            await redact_expired_event_personal_data(session)
-    await warm_jwks_cache()  # JWKS 미리 로드 — 첫 요청 블로킹 방지
-    yield
+    try:
+        await db.create_database()
+        async with db.async_session_factory() as session:
+            await ensure_admin_console_seed_data(session)
+            if PRIVACY_REDACTION_RUN_ON_STARTUP:
+                await redact_expired_event_personal_data(session)
+        await warm_jwks_cache()  # JWKS 미리 로드 — 첫 요청 블로킹 방지
+        yield
+    finally:
+        await db.dispose()
 
 # docs_url, openapi_url을 None으로 비활성화
 app = FastAPI(

--- a/backend/app/tests/test_db_lifecycle.py
+++ b/backend/app/tests/test_db_lifecycle.py
@@ -16,7 +16,7 @@ class SessionContext:
         return False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_session_commits_and_returns_session():
     database = Database()
     session = MagicMock(commit=AsyncMock(), rollback=AsyncMock())
@@ -32,7 +32,7 @@ async def test_get_session_commits_and_returns_session():
     session.rollback.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_session_rolls_back_and_propagates_endpoint_exception():
     database = Database()
     session = MagicMock(commit=AsyncMock(), rollback=AsyncMock())
@@ -64,7 +64,7 @@ def test_initialize_uses_bounded_environment_overridable_pool(monkeypatch):
     assert options["pool_use_lifo"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispose_closes_initialized_engine():
     database = Database()
     database.async_engine = MagicMock(dispose=AsyncMock())

--- a/backend/app/tests/test_db_lifecycle.py
+++ b/backend/app/tests/test_db_lifecycle.py
@@ -1,0 +1,78 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.db import Database, calculate_max_pool_clients
+
+
+class SessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_get_session_commits_and_returns_session():
+    database = Database()
+    session = MagicMock(commit=AsyncMock(), rollback=AsyncMock())
+    database.async_session_factory = MagicMock(return_value=SessionContext(session))
+
+    dependency = database.get_session()
+
+    assert await anext(dependency) is session
+    with pytest.raises(StopAsyncIteration):
+        await anext(dependency)
+
+    session.commit.assert_awaited_once()
+    session.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_session_rolls_back_and_propagates_endpoint_exception():
+    database = Database()
+    session = MagicMock(commit=AsyncMock(), rollback=AsyncMock())
+    database.async_session_factory = MagicMock(return_value=SessionContext(session))
+    dependency = database.get_session()
+    await anext(dependency)
+
+    with pytest.raises(RuntimeError, match="endpoint failed"):
+        await dependency.athrow(RuntimeError("endpoint failed"))
+
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()
+
+
+def test_initialize_uses_bounded_environment_overridable_pool(monkeypatch):
+    monkeypatch.setenv("DB_URL", "postgresql+asyncpg://example.invalid/postgres")
+    monkeypatch.setenv("DB_POOL_SIZE", "4")
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "2")
+    monkeypatch.setenv("DB_POOL_TIMEOUT_SECONDS", "7")
+    engine = MagicMock()
+
+    with patch("core.db.create_async_engine", return_value=engine) as create_engine:
+        Database().initialize()
+
+    options = create_engine.call_args.kwargs
+    assert options["pool_size"] == 4
+    assert options["max_overflow"] == 2
+    assert options["pool_timeout"] == 7
+    assert options["pool_use_lifo"] is True
+
+
+@pytest.mark.asyncio
+async def test_dispose_closes_initialized_engine():
+    database = Database()
+    database.async_engine = MagicMock(dispose=AsyncMock())
+
+    await database.dispose()
+
+    database.async_engine.dispose.assert_awaited_once()
+
+
+def test_pool_capacity_formula_for_production_hotfix_topology():
+    assert calculate_max_pool_clients(replicas=2, workers=2, pool_size=3, max_overflow=1) == 16

--- a/docs/handoffs/2026-08-16-concurrency-incident-fix.md
+++ b/docs/handoffs/2026-08-16-concurrency-incident-fix.md
@@ -34,12 +34,13 @@
 
 ## Validation
 - Backend: `PYTHONPATH=app /tmp/event-bingo-concurrency-venv/bin/pytest -q` — 157 passed, 2 DB integration tests skipped, 1 pre-existing Pydantic deprecation warning.
+- Backend DB integration: GitHub Actions `Backend DB Integration` — passed against the guarded PostgreSQL service.
 - Frontend unit: `npm test` — 109 passed.
 - Frontend lint: `npm run lint` — passed.
 - Frontend build/type check: `npm run build` — passed; existing large-chunk warning remains.
 - Frontend E2E: `npm run e2e` — 19 passed.
 - `git diff --check` — passed.
-- Not run: guarded backend DB integration tests, 50-client/10-minute staging load test, and production-shaped participant-search `EXPLAIN (ANALYZE, BUFFERS)`. No safe staging database target or credentials were supplied.
+- Not run: 50-client/10-minute staging load test and production-shaped participant-search `EXPLAIN (ANALYZE, BUFFERS)`. No safe staging database target or credentials were supplied.
 
 ## Rollout And Rollback
 - Roll out the backend and frontend together because the API search minimum and polling behavior are coordinated contract changes.

--- a/docs/handoffs/2026-08-16-concurrency-incident-fix.md
+++ b/docs/handoffs/2026-08-16-concurrency-incident-fix.md
@@ -1,0 +1,57 @@
+# Event BINGO concurrency incident fix handoff
+
+## Task Metadata
+- Task ID: 2026-08-16-concurrency-incident-fix
+
+## Scope
+- In scope: bounded backend database pooling and lifecycle, active-game polling pressure, participant-search request control, Supabase Auth bridge single-flight/rate-limit handling, automated regression coverage, rollout guidance.
+- Out of scope: Supabase secret or compute changes, GitOps topology changes, the P1 combined state-sync/realtime endpoint, and production database index changes without production-shaped `EXPLAIN` evidence.
+
+## Workspace
+- Worktree path: `/home/ubuntu/code/workspace-bingo-concurrency`
+- Branch: `fix/incident-20260816-concurrency`
+- Base: `origin/main` at `1c9bc119e00185b00b7b0d49b0a701e24baf5008`
+
+## Inputs Used
+- Source docs: `AGENTS.md`, `docs/reference/agent-collaboration.md`
+- Incident inputs: root-workspace `handoff.md`, `Logs-2026-08-16 20_32_20.txt`
+- Incident evidence: 181 Supavisor `EMAXCONN` records, 178 HTTP 500 responses, and a peak of approximately 23.2 RPS during the 2026-08-16 failure window.
+
+## Root Cause
+- The backend used `NullPool`, so request bursts repeatedly opened Supavisor clients without an application-side concurrency ceiling.
+- The yielded session dependency swallowed SQLAlchemy exceptions, which obscured failures, and the application lifespan did not dispose the engine.
+- Every active game browser issued two state requests every five seconds, creating about 20 RPS at 50 continuously active clients before other traffic.
+- Participant search could leave superseded requests running, while Google login/session restoration could initialize the same bridge concurrently and burst `PUT /auth/v1/user` calls.
+
+## Changes Made
+- Backend database sessions now use `async_sessionmaker` directly with a bounded async engine pool. Defaults are `pool_size=3`, `max_overflow=1`, `pool_timeout=5`, `pool_recycle=300`, pre-ping, and LIFO; the first three values are environment-overridable.
+- Session failures now roll back and re-raise. Lifespan shutdown disposes the engine, including startup-failure cleanup.
+- Default maximum application pool clients are calculated as `replicas × workers × (pool_size + max_overflow)`. With the current two replicas and two workers, the ceiling is `2 × 2 × (3 + 1) = 16`.
+- Active game polling now uses a 10-second base interval plus stable per-client jitter from 0–2 seconds, pauses while the document is hidden, immediately refreshes after visibility returns, preserves the in-flight guard, and backs off up to 60 seconds after failures.
+- Participant search now rejects fewer than two characters, retains its 300 ms debounce, aborts superseded requests, and caches successful identical queries for 15 seconds. The backend query contract now also enforces two characters.
+- Google bridge initialization is single-flight per Supabase user/event. Matching metadata updates are skipped, and first-time metadata persistence retries 429 responses after bounded 250 ms and 500 ms delays.
+- Polling E2E timing assertions were aligned with the new 10–12-second state-sync contract.
+
+## Validation
+- Backend: `PYTHONPATH=app /tmp/event-bingo-concurrency-venv/bin/pytest -q` — 157 passed, 2 DB integration tests skipped, 1 pre-existing Pydantic deprecation warning.
+- Frontend unit: `npm test` — 109 passed.
+- Frontend lint: `npm run lint` — passed.
+- Frontend build/type check: `npm run build` — passed; existing large-chunk warning remains.
+- Frontend E2E: `npm run e2e` — 19 passed.
+- `git diff --check` — passed.
+- Not run: guarded backend DB integration tests, 50-client/10-minute staging load test, and production-shaped participant-search `EXPLAIN (ANALYZE, BUFFERS)`. No safe staging database target or credentials were supplied.
+
+## Rollout And Rollback
+- Roll out the backend and frontend together because the API search minimum and polling behavior are coordinated contract changes.
+- Keep the current GitOps mitigation at two replicas and two workers. Set `DB_POOL_SIZE=3`, `DB_MAX_OVERFLOW=1`, and `DB_POOL_TIMEOUT_SECONDS=5` explicitly in GitOps even though these are application defaults.
+- Use a rolling deployment with readiness checks. During rollout, watch HTTP 5xx, `EMAXCONN`, Supabase Auth 429, p50/p95/p99 latency, and backend CPU throttling.
+- Before full traffic, run 50 active clients for 10 minutes and require zero `EMAXCONN`, less than 1% HTTP 5xx, and preserved board/interaction synchronization.
+- Roll back both application images to `sha-1c9bc11` if error rate or state-sync regressions exceed the gate. Do not revert GitOps hotfix `60f93b6`; retain two replicas/two workers during rollback.
+
+## Risks
+- Known risks: application metrics do not yet expose SQLAlchemy checked-out/overflow/wait values or dedicated Auth 429/`EMAXCONN` counters; production-shaped search plans and index needs remain unverified; polling still makes two requests per cycle; the load-test acceptance gate remains open.
+- Follow-up needed: staging load test and latency report, safe production-shaped search `EXPLAIN`, pool/route/Auth observability, and P1 combined state-sync or realtime evaluation.
+
+## Next Owner
+- Owner: QA, then Infra/GitOps lead for staged rollout.
+- Expected next action: run the missing DB integration and 50-client staging tests, attach metrics/latencies to the PR, set explicit pool environment values in `Pseudo-Lab/DevFactory-Ops`, and approve rollout only if all incident gates pass.

--- a/frontend/e2e/bingo-completion.spec.ts
+++ b/frontend/e2e/bingo-completion.spec.ts
@@ -82,7 +82,7 @@ test("updates the board from incoming exchanges and celebrates when the bingo go
   await expect(page.locator(".bingo-board-cell.is-complete")).toHaveCount(0);
 
   await expect(page.getByRole("heading", { name: "빙고를 완성했어요" })).toBeVisible({
-    timeout: 8000,
+    timeout: 15_000,
   });
   await expect(page.getByText("3줄 미션을 달성했습니다.")).toBeVisible();
   await expect(page.locator(".bingo-board-cell.is-complete")).toHaveCount(15);

--- a/frontend/e2e/exchange.spec.ts
+++ b/frontend/e2e/exchange.spec.ts
@@ -203,7 +203,7 @@ test.describe("mobile touch", () => {
     expect(await page.evaluate(() => window.scrollY)).toBe(0);
 
     await expect
-      .poll(() => page.evaluate(() => window.scrollY), { timeout: 7000 })
+      .poll(() => page.evaluate(() => window.scrollY), { timeout: 15_000 })
       .toBeGreaterThan(0);
     const latestCell = page.locator(".bingo-board-cell.is-latest");
     await expect(latestCell).toContainText(incomingKeyword);
@@ -273,7 +273,7 @@ test.describe("mobile touch", () => {
     await expect(page.getByLabel("상대방 이름 검색")).toBeVisible();
 
     const latestCell = page.locator(".bingo-board-cell.is-latest");
-    await expect(latestCell).toContainText(duplicateKeyword, { timeout: 7000 });
+    await expect(latestCell).toContainText(duplicateKeyword, { timeout: 15_000 });
     await expect
       .poll(() =>
         latestCell.evaluate((element) => getComputedStyle(element).animationName)

--- a/frontend/src/api/bingo_api.search.test.ts
+++ b/frontend/src/api/bingo_api.search.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/apiBase", () => ({
+  getApiBaseUrl: () => "http://api.test",
+}));
+
+vi.mock("../lib/supabaseClient", () => ({
+  maybeGetSupabaseClient: () => null,
+}));
+
+import { searchBingoParticipants } from "./bingo_api";
+
+describe("searchBingoParticipants", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not request queries shorter than two characters", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(searchBingoParticipants("김", "sample-event")).resolves.toEqual([]);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes the abort signal and caches a successful identical search", async () => {
+    const abortController = new AbortController();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          message: "ok",
+          participants: [{ user_id: 9, display_name: "김승규" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const first = await searchBingoParticipants(
+      "김승규",
+      "cache-event",
+      "7",
+      abortController.signal
+    );
+    const second = await searchBingoParticipants("김승규", "cache-event", "7");
+
+    expect(first).toEqual([{ user_id: 9, display_name: "김승규" }]);
+    expect(second).toEqual(first);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBe(abortController.signal);
+  });
+});

--- a/frontend/src/api/bingo_api.ts
+++ b/frontend/src/api/bingo_api.ts
@@ -411,28 +411,51 @@ export type BingoParticipantItem = {
   display_name: string;
 };
 
+const PARTICIPANT_SEARCH_CACHE_MS = 15_000;
+const participantSearchCache = new Map<
+  string,
+  { expiresAt: number; participants: BingoParticipantItem[] }
+>();
+
 export const searchBingoParticipants = async (
   query: string,
   eventSlug: string,
-  excludeUserId?: string
+  excludeUserId?: string,
+  signal?: AbortSignal
 ) => {
+  const normalizedQuery = query.trim();
+  if (normalizedQuery.length < 2) {
+    return [];
+  }
+
   if (shouldUseMockApi()) {
-    return mockSearchBingoParticipants(query, excludeUserId);
+    return mockSearchBingoParticipants(normalizedQuery, excludeUserId);
+  }
+
+  const cacheKey = `${eventSlug}:${excludeUserId ?? ""}:${normalizedQuery}`;
+  const cached = participantSearchCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.participants;
   }
 
   const data = await requestJson<
     ApiResponseBase & { participants?: BingoParticipantItem[] }
   >(
     "/api/auth/bingo/search",
-    { method: "GET" },
+    { method: "GET", signal },
     {
-      q: query,
+      q: normalizedQuery,
       event_slug: eventSlug,
       ...(excludeUserId ? { exclude_user_id: excludeUserId } : {}),
     }
   );
 
-  return data.participants ?? [];
+  const participants = data.participants ?? [];
+  participantSearchCache.set(cacheKey, {
+    expiresAt: Date.now() + PARTICIPANT_SEARCH_CACHE_MS,
+    participants,
+  });
+  return participants;
 };
 
 export const updateBingoDisplayName = async (userId: string, eventSlug: string, displayName: string) => {

--- a/frontend/src/modules/Bingo/BingoGame.tsx
+++ b/frontend/src/modules/Bingo/BingoGame.tsx
@@ -68,6 +68,7 @@ import {
   writeBingoGameLanguage,
 } from "./bingoGameLanguage";
 import type { BingoGameLanguage } from "./bingoGameLanguage";
+import { getStablePollJitter, startVisibilityAwarePolling } from "./bingoPolling";
 import { syncTestModeFromUrl } from "../../utils/testMode";
 import {
   readGoalCelebrationFlag as readStoredGoalCelebrationFlag,
@@ -197,6 +198,7 @@ const BingoGame = () => {
   const [nameSetupMode, setNameSetupMode] = useState<"new-board" | "existing-board">("new-board");
   const [nameInput, setNameInput] = useState("");
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const opponentSearchAbortRef = useRef<AbortController | null>(null);
   const opponentInputRef = useRef<HTMLInputElement | null>(null);
   const opponentSearchRequestIdRef = useRef(0);
   const [completedLines, setCompletedLines] = useState<CompletedLine[]>([]);
@@ -594,6 +596,7 @@ const BingoGame = () => {
         });
       } catch (error) {
         console.error("Error refreshing bingo board:", error);
+        return false;
       } finally {
         isPollingRef.current = false;
       }
@@ -790,12 +793,12 @@ const BingoGame = () => {
       return;
     }
 
-    const interval = setInterval(() => {
-      void refreshBingoState(userId);
-    }, 5000);
-
-    return () => clearInterval(interval);
-  }, [refreshBingoState, userId, initialSetupOpen, nameSetupOpen]);
+    return startVisibilityAwarePolling({
+      document,
+      jitterMs: getStablePollJitter(`${eventSlug ?? "event"}:${userId}`),
+      poll: async () => (await refreshBingoState(userId)) !== false,
+    });
+  }, [eventSlug, refreshBingoState, userId, initialSetupOpen, nameSetupOpen]);
 
   const resetPreviewVisualState = useCallback(() => {
     setShowAllBingoModal(false);
@@ -1126,8 +1129,10 @@ const BingoGame = () => {
       if (searchTimeoutRef.current) {
         clearTimeout(searchTimeoutRef.current);
       }
+      opponentSearchAbortRef.current?.abort();
+      opponentSearchAbortRef.current = null;
 
-      if (normalizedQuery.length === 0) {
+      if (normalizedQuery.length < 2) {
         setOpponentSearchResults([]);
         setIsSearching(false);
         return;
@@ -1142,12 +1147,15 @@ const BingoGame = () => {
       setIsSearching(true);
       const requestId = opponentSearchRequestIdRef.current;
       searchTimeoutRef.current = setTimeout(async () => {
+        const abortController = new AbortController();
+        opponentSearchAbortRef.current = abortController;
         try {
           const activeUserId = userId || getAuthSession()?.userId || "";
           const results = await searchBingoParticipants(
             normalizedQuery,
             normalizedEventSlug,
-            activeUserId || undefined
+            activeUserId || undefined,
+            abortController.signal
           );
           if (requestId !== opponentSearchRequestIdRef.current) {
             return;
@@ -1164,11 +1172,23 @@ const BingoGame = () => {
           if (requestId === opponentSearchRequestIdRef.current) {
             setIsSearching(false);
           }
+          if (opponentSearchAbortRef.current === abortController) {
+            opponentSearchAbortRef.current = null;
+          }
         }
       }, 300);
     },
     [eventSlug, userId]
   );
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+      opponentSearchAbortRef.current?.abort();
+    };
+  }, []);
 
   const handleSelectOpponent = useCallback(
     (user: BingoParticipantItem) => {

--- a/frontend/src/modules/Bingo/bingoPolling.test.ts
+++ b/frontend/src/modules/Bingo/bingoPolling.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getStablePollJitter,
+  startVisibilityAwarePolling,
+} from "./bingoPolling";
+
+const createVisibilityDocument = () => {
+  let visibilityState: DocumentVisibilityState = "visible";
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+
+  return {
+    document: {
+      addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners.delete(listener);
+      },
+      get visibilityState() {
+        return visibilityState;
+      },
+    } as Pick<Document, "addEventListener" | "removeEventListener" | "visibilityState">,
+    setVisibility(nextState: DocumentVisibilityState) {
+      visibilityState = nextState;
+      listeners.forEach((listener) => {
+        if (typeof listener === "function") {
+          listener(new Event("visibilitychange"));
+        } else {
+          listener.handleEvent(new Event("visibilitychange"));
+        }
+      });
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("bingo polling", () => {
+  it("uses stable bounded jitter per client", () => {
+    expect(getStablePollJitter("event:42")).toBe(getStablePollJitter("event:42"));
+    expect(getStablePollJitter("event:42")).toBeGreaterThanOrEqual(0);
+    expect(getStablePollJitter("event:42")).toBeLessThanOrEqual(2_000);
+  });
+
+  it("polls after the base interval and client jitter", async () => {
+    vi.useFakeTimers();
+    const visibility = createVisibilityDocument();
+    const poll = vi.fn().mockResolvedValue(true);
+    const stop = startVisibilityAwarePolling({
+      document: visibility.document,
+      jitterMs: 500,
+      intervalMs: 10_000,
+      poll,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_499);
+    expect(poll).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(poll).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("pauses while hidden and refreshes immediately when visible", async () => {
+    vi.useFakeTimers();
+    const visibility = createVisibilityDocument();
+    const poll = vi.fn().mockResolvedValue(true);
+    const stop = startVisibilityAwarePolling({
+      document: visibility.document,
+      jitterMs: 0,
+      intervalMs: 10_000,
+      poll,
+    });
+
+    visibility.setVisibility("hidden");
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(poll).not.toHaveBeenCalled();
+    visibility.setVisibility("visible");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(poll).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("backs off after failures and resets after success", async () => {
+    vi.useFakeTimers();
+    const visibility = createVisibilityDocument();
+    const poll = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+    const stop = startVisibilityAwarePolling({
+      document: visibility.document,
+      jitterMs: 0,
+      intervalMs: 1_000,
+      maxBackoffMs: 8_000,
+      poll,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(poll).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(poll).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(poll).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(poll).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it("cleans up its timer and visibility listener", async () => {
+    vi.useFakeTimers();
+    const visibility = createVisibilityDocument();
+    const poll = vi.fn().mockResolvedValue(true);
+    const stop = startVisibilityAwarePolling({
+      document: visibility.document,
+      jitterMs: 0,
+      intervalMs: 1_000,
+      poll,
+    });
+
+    expect(visibility.listenerCount()).toBe(1);
+    stop();
+    expect(visibility.listenerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(poll).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/modules/Bingo/bingoPolling.ts
+++ b/frontend/src/modules/Bingo/bingoPolling.ts
@@ -1,0 +1,85 @@
+export const BINGO_POLL_INTERVAL_MS = 10_000;
+export const BINGO_POLL_MAX_BACKOFF_MS = 60_000;
+export const BINGO_POLL_MAX_JITTER_MS = 2_000;
+
+export const getStablePollJitter = (clientKey: string, maxJitterMs = BINGO_POLL_MAX_JITTER_MS) => {
+  let hash = 0;
+  for (let index = 0; index < clientKey.length; index += 1) {
+    hash = (hash * 31 + clientKey.charCodeAt(index)) >>> 0;
+  }
+  return maxJitterMs > 0 ? hash % (maxJitterMs + 1) : 0;
+};
+
+type PollingOptions = {
+  document: Pick<Document, "addEventListener" | "removeEventListener" | "visibilityState">;
+  jitterMs: number;
+  poll: () => Promise<boolean>;
+  intervalMs?: number;
+  maxBackoffMs?: number;
+};
+
+export const startVisibilityAwarePolling = ({
+  document,
+  jitterMs,
+  poll,
+  intervalMs = BINGO_POLL_INTERVAL_MS,
+  maxBackoffMs = BINGO_POLL_MAX_BACKOFF_MS,
+}: PollingOptions) => {
+  let stopped = false;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let consecutiveFailures = 0;
+  let running = false;
+
+  const clearScheduledPoll = () => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const schedule = () => {
+    clearScheduledPoll();
+    if (stopped || document.visibilityState === "hidden") {
+      return;
+    }
+
+    const backoffMs = Math.min(
+      intervalMs * 2 ** consecutiveFailures,
+      maxBackoffMs
+    );
+    timeoutId = setTimeout(run, backoffMs + jitterMs);
+  };
+
+  const run = async () => {
+    if (stopped || running || document.visibilityState === "hidden") {
+      return;
+    }
+
+    running = true;
+    try {
+      const succeeded = await poll();
+      consecutiveFailures = succeeded ? 0 : consecutiveFailures + 1;
+    } catch {
+      consecutiveFailures += 1;
+    } finally {
+      running = false;
+      schedule();
+    }
+  };
+
+  const handleVisibilityChange = () => {
+    clearScheduledPoll();
+    if (document.visibilityState === "visible") {
+      void run();
+    }
+  };
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  schedule();
+
+  return () => {
+    stopped = true;
+    clearScheduledPoll();
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  };
+};

--- a/frontend/src/utils/bingoGoogleBridge.test.ts
+++ b/frontend/src/utils/bingoGoogleBridge.test.ts
@@ -160,4 +160,70 @@ describe("bingoGoogleBridge", () => {
       },
     });
   });
+
+  it("skips the auth metadata update when the bingo name is unchanged", async () => {
+    getUser.mockResolvedValue({
+      data: {
+        user: {
+          user_metadata: {
+            event_bingo_user_name: "행사 이름",
+          },
+        },
+      },
+    });
+
+    await syncBingoBridgeUserName("행사 이름");
+
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it("initializes the bridge only once for concurrent calls from the same user", async () => {
+    registerBingoUser.mockResolvedValue({
+      ok: true,
+      message: "빙고 계정이 생성되었습니다.",
+      user_id: 11,
+      login_id: "ABCD12",
+      user_email: "tester@example.com",
+      user_name: null,
+    });
+    const user = createGoogleUser() as never;
+
+    const [first, second] = await Promise.all([
+      ensureBingoGoogleBridge(user, "sample-event"),
+      ensureBingoGoogleBridge(user, "sample-event"),
+    ]);
+
+    expect(registerBingoUser).toHaveBeenCalledTimes(1);
+    expect(updateUser).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+  });
+
+  it("retries auth metadata updates with bounded backoff after 429", async () => {
+    vi.useFakeTimers();
+    registerBingoUser.mockResolvedValue({
+      ok: true,
+      message: "빙고 계정이 생성되었습니다.",
+      user_id: 11,
+      login_id: "ABCD12",
+      user_email: "tester@example.com",
+      user_name: null,
+    });
+    updateUser
+      .mockResolvedValueOnce({ error: { status: 429 } })
+      .mockResolvedValueOnce({ error: { status: 429 } })
+      .mockResolvedValueOnce({ error: null });
+
+    const initialization = ensureBingoGoogleBridge(
+      createGoogleUser() as never,
+      "rate-limited-event"
+    );
+    await vi.advanceTimersByTimeAsync(249);
+    expect(updateUser).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(updateUser).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(500);
+    await initialization;
+    expect(updateUser).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/utils/bingoGoogleBridge.ts
+++ b/frontend/src/utils/bingoGoogleBridge.ts
@@ -14,6 +14,7 @@ const LOGIN_ID_METADATA_KEY = "event_bingo_login_id";
 const BRIDGE_KEY_METADATA_KEY = "event_bingo_bridge_key";
 const USER_ID_METADATA_KEY = "event_bingo_user_id";
 const USER_NAME_METADATA_KEY = "event_bingo_user_name";
+const AUTH_UPDATE_RETRY_DELAYS_MS = [250, 500];
 
 type BingoBridgeMetadata = {
   bridgeKey?: string;
@@ -42,6 +43,8 @@ export type BingoGoogleBridgeResult = {
   googleProfile: BingoGoogleProfile;
   isNewUser: boolean;
 };
+
+const bridgeInitializationByUser = new Map<string, Promise<BingoGoogleBridgeResult>>();
 
 const pickString = (value: unknown) => (typeof value === "string" ? value.trim() : "");
 
@@ -114,7 +117,6 @@ const updateBingoBridgeMetadata = async (
   authSession: AuthSession,
   bridgeKey: string
 ) => {
-  const supabase = getSupabaseClient();
   const nextMetadata = {
     ...(user.user_metadata ?? {}),
     [BRIDGE_KEY_METADATA_KEY]: bridgeKey,
@@ -123,12 +125,36 @@ const updateBingoBridgeMetadata = async (
     [USER_NAME_METADATA_KEY]: authSession.userName,
   };
 
-  const { error } = await supabase.auth.updateUser({
-    data: nextMetadata,
-  });
+  const currentMetadata = user.user_metadata ?? {};
+  const metadataAlreadyMatches =
+    pickString(currentMetadata[BRIDGE_KEY_METADATA_KEY]) === bridgeKey &&
+    pickString(currentMetadata[LOGIN_ID_METADATA_KEY]) === authSession.loginId &&
+    pickString(currentMetadata[USER_ID_METADATA_KEY]) === authSession.userId &&
+    pickString(currentMetadata[USER_NAME_METADATA_KEY]) === authSession.userName;
+  if (metadataAlreadyMatches) {
+    return;
+  }
 
-  if (error) {
-    console.warn("Failed to persist bingo bridge metadata.", error);
+  const supabase = getSupabaseClient();
+
+  for (let attempt = 0; attempt <= AUTH_UPDATE_RETRY_DELAYS_MS.length; attempt += 1) {
+    const { error } = await supabase.auth.updateUser({
+      data: nextMetadata,
+    });
+
+    if (!error) {
+      return;
+    }
+
+    const status = "status" in error ? error.status : undefined;
+    if (status !== 429 || attempt === AUTH_UPDATE_RETRY_DELAYS_MS.length) {
+      console.warn("Failed to persist bingo bridge metadata.", error);
+      return;
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, AUTH_UPDATE_RETRY_DELAYS_MS[attempt]);
+    });
   }
 };
 
@@ -165,7 +191,7 @@ export const syncBingoBridgeUserName = async (userName: string) => {
   }
 };
 
-export const ensureBingoGoogleBridge = async (
+const initializeBingoGoogleBridge = async (
   user: User,
   eventSlug?: string
 ): Promise<BingoGoogleBridgeResult> => {
@@ -222,4 +248,24 @@ export const ensureBingoGoogleBridge = async (
     googleProfile,
     isNewUser: true,
   };
+};
+
+export const ensureBingoGoogleBridge = (
+  user: User,
+  eventSlug?: string
+): Promise<BingoGoogleBridgeResult> => {
+  const userKey = pickString(user.id) || pickString(user.email);
+  const initializationKey = `${userKey}:${eventSlug ?? ""}`;
+  const pendingInitialization = bridgeInitializationByUser.get(initializationKey);
+  if (pendingInitialization) {
+    return pendingInitialization;
+  }
+
+  const initialization = initializeBingoGoogleBridge(user, eventSlug).finally(() => {
+    if (bridgeInitializationByUser.get(initializationKey) === initialization) {
+      bridgeInitializationByUser.delete(initializationKey);
+    }
+  });
+  bridgeInitializationByUser.set(initializationKey, initialization);
+  return initialization;
 };


### PR DESCRIPTION
## Use This Template When
- 이 PR은 `main` 직접 푸시가 아닌 영향 변경 검토용입니다.

## Summary
- Task ID: 2026-08-16-concurrency-incident-fix
- 2026-08-16 이벤트 트래픽에서 발생한 Supavisor 연결 고갈과 요청 증폭을 완화합니다.

## Impact Trigger (Select At Least One)
- [x] Cross-domain change (BE/FE/Infra)
- [x] API/Auth/DB schema or migration change affecting another domain
- [ ] Source-of-truth guide change under docs/*.md
- [ ] CI/CD, deployment, security, ingress, secrets, or runtime topology change
- [ ] Explicit review requested by Product Owner or relevant domain owner

## Domains Affected
- [x] BE (`backend/**`)
- [x] FE (`frontend/**`)
- [ ] Infra (`.github/workflows/**`, `docker-compose.yaml`, `k8s/**`, ops manifests)

## Source Documents
- [ ] docs/reference/project-requirements.md
- [ ] docs/reference/service-user-flow.md
- [ ] docs/reference/design-guide.md (if applicable)
- [x] docs/reference/agent-collaboration.md

## Changes
- SQLAlchemy 세션을 요청 단위 `async_sessionmaker`로 단순화하고 풀을 프로세스별 기본 3+1개로 제한했습니다.
- 예외 롤백/재전파와 lifespan 종료 시 엔진 dispose를 보장했습니다.
- 폴링을 10초 + 클라이언트별 0~2초 지터로 조정하고 hidden 중지, visible 즉시 갱신, 실패 백오프를 추가했습니다.
- 참가자 검색에 2자 제한, 이전 요청 취소, 15초 캐시를 적용했습니다.
- Google bridge 초기화를 사용자/이벤트별 single-flight로 만들고 Auth 429에 제한된 백오프를 적용했습니다.
- 연결 상한: `2 replicas × 2 workers × (3 pool + 1 overflow) = 16`입니다.

## Validation
- Tests: backend pytest, guarded PostgreSQL integration, frontend Vitest/lint/type-check/build, full Playwright E2E, Docker builds, diff check
- Result: backend 157 passed, DB integration passed, frontend unit 109 passed, Playwright 19 passed, lint/build 및 backend/frontend Docker build passed
- Not run and reason: staging DB/credentials가 없어 활성 클라이언트 50명 10분 부하 테스트와 production-shaped 검색 EXPLAIN은 미실행입니다.

## Guide Sync Check
- [x] 영어 source-of-truth guide 변경 없음 — Korean mirror 동기화 불필요

## Handoff
- [x] `docs/handoffs/2026-08-16-concurrency-incident-fix.md` 추가

## 병합 전 필수 게이트
- [ ] staging 활성 클라이언트 50명, 10분 부하 테스트
- [ ] EMAXCONN 0건, HTTP 5xx 1% 미만, p50/p95/p99 및 RPS 기록
- [ ] production-shaped 참가자 검색 `EXPLAIN (ANALYZE, BUFFERS)` 첨부
- [ ] GitOps에 `DB_POOL_SIZE=3`, `DB_MAX_OVERFLOW=1`, `DB_POOL_TIMEOUT_SECONDS=5` 명시
- [ ] issue #81 관련 동작 포함 최종 QA 승인